### PR TITLE
Feature/improve cli

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,5 +1,5 @@
-# .github/workflows/website-downloader.yml
-name: Website Downloader CI
+# .github/workflows/ci.yml
+name: CI – Website Downloader
 
 on:
   push:
@@ -9,48 +9,37 @@ on:
   workflow_dispatch:
 
 jobs:
-  download:
+  test-mirror:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
-      fail-fast: false
+        python-version: ['3.9', '3.10', '3.11']   # run on three CPython versions
 
     steps:
-      # --- Setup ----------------------------------------------------------------
-      - name: ⬇️  Checkout source
+      - name: 📥 Checkout source
         uses: actions/checkout@v4
 
-      - name: 🐍  Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: 🐍 Set-up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-      # --- Dependency cache -----------------------------------------------------
-      - name: 📦  Cache pip wheel-house
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
-
-      - name: 🔧  Install dependencies
+      - name: 📦 Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      # --- Run the crawler ------------------------------------------------------
-      - name: 🌐  Mirror target site
+      - name: 🚀 Smoke-test: mirror 5 pages
         run: |
-          python website_downloader.py \
+          python website-downloader.py \
                  --url "https://harsim.ca/" \
-                 --destination "archive" \
-                 --max-pages 30
+                 --destination "_mirror" \
+                 --max-pages 5
 
-      # --- Upload artifact ------------------------------------------------------
-      - name: 📤  Publish archive
+      - name: 📦 Upload mirrored site (artefact)
         uses: actions/upload-artifact@v4
         with:
-          name: harsimca_${{ matrix.python-version }}
-          path: archive
-          retention-days: 7
+          name: mirrored_site_py${{ matrix.python-version }}
+          path: _mirror

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,38 +1,56 @@
-name: Test Website Downloader
+# .github/workflows/website-downloader.yml
+name: Website Downloader CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  build:
+  download:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+      fail-fast: false
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      # --- Setup ----------------------------------------------------------------
+      - name: ⬇️  Checkout source
+        uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - name: 🐍  Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      # --- Dependency cache -----------------------------------------------------
+      - name: 📦  Cache pip wheel-house
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: >-
+            ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
+
+      - name: 🔧  Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run website downloader
-        env:
-          URL_TO_DOWNLOAD: "https://harsim.ca/resume/"
-          DOWNLOAD_DESTINATION: "/path/to/save"
+      # --- Run the crawler ------------------------------------------------------
+      - name: 🌐  Mirror target site
         run: |
-          # Since URL and destination are provided via environment variables,
-          # the script won't prompt for them. It will still prompt for the
-          # check-download question, so we pipe "no" as the answer.
-          printf "no\n" | python website-downloader.py
+          python website_downloader.py \
+                 --url "https://harsim.ca/" \
+                 --destination "archive" \
+                 --max-pages 30
+
+      # --- Upload artifact ------------------------------------------------------
+      - name: 📤  Publish archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: harsimca_${{ matrix.python-version }}
+          path: archive
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -2,14 +2,38 @@
 
 Website Downloader is a powerful Python script designed to download entire websites along with all their assets. This tool allows you to create a local copy of a website, including HTML pages, images, CSS, JavaScript files, and other resources. It ensures that all internal links and resources are downloaded for offline viewing. Perfect for web archiving and offline browsing!
 
-## ✨ Features
+---
 
-- 🔄 Recursively download entire websites.
-- 💾 Save HTML pages with all linked assets.
-- 🔗 Convert links for offline viewing.
-- 🖼️ Handle various file types including images, CSS, and JavaScript.
-- 📜 Log download progress and errors.
-- ✔️ Verify the completeness of the downloaded website and re-download missing files if necessary.
+# CLI Refactor: Moving from input() to argparse
+
+## 🎯 Objective
+
+This update improves the usability and automation of the project by replacing all `input()` prompts with `argparse` command-line flags.
+
+## 🛠️ Changes Made
+
+- Replaced interactive `input()` calls with standard argparse flags:
+  - `--url` for the target website URL
+  - `--destination` for the download folder path
+  - `--max-pages` to set the maximum number of pages to crawl (default = 50)
+- Added `--help` documentation to guide users
+- Enforced required arguments for critical parameters like `--url`
+- Introduced cleaner defaults where applicable (e.g., default output directory)
+
+## ✅ Benefits
+
+- 🧩 **Scriptable**: Can now run the script in automated pipelines or cron jobs
+- 💻 **User-Friendly**: Users can discover options via `--help`
+- 🔁 **Repeatable**: Enables consistent execution with no manual input required
+- 📦 **Future-Proof**: Prepares the project for more advanced CLI features (like subcommands)
+
+## 🗓️ Next Steps (Planned)
+
+- Merge both `website-downloader.py` and `check_download.py` into a unified CLI using subcommands (`download`, `verify`)
+- Add flags for retries, request timeout, include-external-resources, and more
+- Package the project with a `console_scripts` entry point for system-wide usage
+
+---
 
 ## 📥 Installation
 
@@ -58,38 +82,7 @@ Website Downloader is a powerful Python script designed to download entire websi
     - Provides detailed statistics including the total number of HTML files processed, unique resources found, and missing resource percentages.
 - `requirements.txt`: A file listing the required dependencies.
 
----
 
-# CLI Refactor: Moving from input() to argparse
-
-## 🎯 Objective
-
-This update improves the usability and automation of the project by replacing all `input()` prompts with `argparse` command-line flags.
-
-## 🛠️ Changes Made
-
-- Replaced interactive `input()` calls with standard argparse flags:
-  - `--url` for the target website URL
-  - `--destination` for the download folder path
-  - `--max-pages` to set the maximum number of pages to crawl (default = 50)
-- Added `--help` documentation to guide users
-- Enforced required arguments for critical parameters like `--url`
-- Introduced cleaner defaults where applicable (e.g., default output directory)
-
-## ✅ Benefits
-
-- 🧩 **Scriptable**: Can now run the script in automated pipelines or cron jobs
-- 💻 **User-Friendly**: Users can discover options via `--help`
-- 🔁 **Repeatable**: Enables consistent execution with no manual input required
-- 📦 **Future-Proof**: Prepares the project for more advanced CLI features (like subcommands)
-
-## 🗓️ Next Steps (Planned)
-
-- Merge both `website-downloader.py` and `check_download.py` into a unified CLI using subcommands (`download`, `verify`)
-- Add flags for retries, request timeout, include-external-resources, and more
-- Package the project with a `console_scripts` entry point for system-wide usage
-
----
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,38 @@ Website Downloader is a powerful Python script designed to download entire websi
     - Provides detailed statistics including the total number of HTML files processed, unique resources found, and missing resource percentages.
 - `requirements.txt`: A file listing the required dependencies.
 
+---
+
+# CLI Refactor: Moving from input() to argparse
+
+## 🎯 Objective
+
+This update improves the usability and automation of the project by replacing all `input()` prompts with `argparse` command-line flags.
+
+## 🛠️ Changes Made
+
+- Replaced interactive `input()` calls with standard argparse flags:
+  - `--url` for the target website URL
+  - `--destination` for the download folder path
+  - `--max-pages` to set the maximum number of pages to crawl (default = 50)
+- Added `--help` documentation to guide users
+- Enforced required arguments for critical parameters like `--url`
+- Introduced cleaner defaults where applicable (e.g., default output directory)
+
+## ✅ Benefits
+
+- 🧩 **Scriptable**: Can now run the script in automated pipelines or cron jobs
+- 💻 **User-Friendly**: Users can discover options via `--help`
+- 🔁 **Repeatable**: Enables consistent execution with no manual input required
+- 📦 **Future-Proof**: Prepares the project for more advanced CLI features (like subcommands)
+
+## 🗓️ Next Steps (Planned)
+
+- Merge both `website-downloader.py` and `check_download.py` into a unified CLI using subcommands (`download`, `verify`)
+- Add flags for retries, request timeout, include-external-resources, and more
+- Package the project with a `console_scripts` entry point for system-wide usage
+
+---
 
 ## 🤝 Contributing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
-beautifulsoup4
-wget
+requests~=2.32.4
+beautifulsoup4~=4.13.4
+wget~=3.2
+urllib3~=2.5.0


### PR DESCRIPTION
This PR lands the Website Downloader v2.0 rewrite:

- Argparse CLI – --url, --destination, --max-pages, --threads (good-bye input()).
- Single-root output – fixes “double-domain” path bug; pretty URLs (/about/) map to about/index.html.
- Concurrent asset fetch – thread-pool (default 6) slashes download time.
- Robust networking – shared requests.Session with 5-retry exponential back-off and custom UA.
- Link-rewriter 2.0 – rewrites every internal href / src to local relative paths, guaranteeing offline nav.
-  Colourised, structured logging – per-thread logs, crawl stats (total, avg latency).
- Cleaner defaults & help – output folder auto-derived from domain; --help shows all flags.
-  Code health – PEP-621 doc-string header, type hints, helper functions split into logical sections.

CI 🛠️
- New GitHub Actions workflow builds on 3 Python versions, caches pip, and uploads the mirrored site as an artefact.