### PR TITLE
Update website-downloader.py

### DIFF
--- a/website-downloader.py
+++ b/website-downloader.py
@@ -163,6 +163,7 @@ SESSION.mount("http://", HTTPAdapter(max_retries=RETRY_STRAT))
 SESSION.mount("https://", HTTPAdapter(max_retries=RETRY_STRAT))
 SESSION.headers.update(DEFAULT_HEADERS)
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -450,15 +451,15 @@ def _protocol_fix(url: str, base_url: str) -> str:
 
 
 def rewrite_css_text(
-    css_text: str,
-    base_url: str,
-    *,
-    site_root: Path,
-    root_netloc: str,
-    base_dir: Path,
-    download_external_assets: bool,
-external_domains: Optional[set[str]] = None,
-    download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
+        css_text: str,
+        base_url: str,
+        *,
+        site_root: Path,
+        root_netloc: str,
+        base_dir: Path,
+        download_external_assets: bool,
+        external_domains: Optional[set[str]] = None,
+        download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
 ) -> str:
     """
     Rewrite CSS url(...) and @import references to local relative paths.
@@ -559,15 +560,15 @@ external_domains: Optional[set[str]] = None,
 
 
 def rewrite_js_text(
-    js_text: str,
-    base_url: str,
-    *,
-    site_root: Path,
-    root_netloc: str,
-    base_dir: Path,
-    download_external_assets: bool,
-    external_domains: Optional[set[str]] = None,
-    download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
+        js_text: str,
+        base_url: str,
+        *,
+        site_root: Path,
+        root_netloc: str,
+        base_dir: Path,
+        download_external_assets: bool,
+        external_domains: Optional[set[str]] = None,
+        download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
 ) -> str:
     """
     Rewrite obvious static asset URL strings inside JS.
@@ -654,7 +655,7 @@ def _canonical_netloc(parsed: ParseResult) -> str:
         return parsed.netloc.lower()
 
     if (parsed.scheme == "https" and port == 443) or (
-        parsed.scheme == "http" and port == 80
+            parsed.scheme == "http" and port == 80
     ):
         port = None
 
@@ -720,14 +721,14 @@ def fetch_html(url: str) -> Optional[BeautifulSoup]:
 
 
 def fetch_binary(
-    url: str,
-    dest: Path,
-    download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
-    *,
-    site_root: Optional[Path] = None,
-    root_netloc: str = "",
-    download_external_assets: bool = False,
-    external_domains: Optional[set[str]] = None,
+        url: str,
+        dest: Path,
+        download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
+        *,
+        site_root: Optional[Path] = None,
+        root_netloc: str = "",
+        download_external_assets: bool = False,
+        external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Stream a binary/static resource to disk.
@@ -775,10 +776,10 @@ def fetch_binary(
         # If we downloaded CSS, rewrite its url(...) and @import references,
         # and enqueue referenced assets (images/fonts/etc).
         if (
-            dest.suffix.lower() == ".css"
-            and download_q is not None
-            and site_root is not None
-            and root_netloc
+                dest.suffix.lower() == ".css"
+                and download_q is not None
+                and site_root is not None
+                and root_netloc
         ):
             try:
                 css_text = dest.read_text(encoding="utf-8", errors="ignore")
@@ -800,10 +801,10 @@ def fetch_binary(
         # If we downloaded JS, rewrite obvious static URL strings,
         # and enqueue referenced assets (only those matching ASSET_EXTENSIONS).
         if (
-            dest.suffix.lower() in {".js", ".mjs"}
-            and download_q is not None
-            and site_root is not None
-            and root_netloc
+                dest.suffix.lower() in {".js", ".mjs"}
+                and download_q is not None
+                and site_root is not None
+                and root_netloc
         ):
             try:
                 js_text = dest.read_text(encoding="utf-8", errors="ignore")
@@ -832,12 +833,12 @@ def fetch_binary(
 
 
 def rewrite_links(
-    soup: BeautifulSoup,
-    page_url: str,
-    site_root: Path,
-    page_dir: Path,
-    download_external_assets: bool = False,
-    external_domains: Optional[set[str]] = None,
+        soup: BeautifulSoup,
+        page_url: str,
+        site_root: Path,
+        page_dir: Path,
+        download_external_assets: bool = False,
+        external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Rewrite HTML so it can be opened offline.
@@ -869,7 +870,7 @@ def rewrite_links(
                 rel = [rel]
             rel = [r.lower() for r in rel]
             if not any(
-                r in rel for r in ("stylesheet", "icon", "preload", "modulepreload")
+                    r in rel for r in ("stylesheet", "icon", "preload", "modulepreload")
             ):
                 continue
 
@@ -886,9 +887,9 @@ def rewrite_links(
 
             # Skip anchors, non-fetchable schemes, and things that are not http(s)/relative.
             if (
-                original.startswith("#")
-                or is_non_fetchable(original)
-                or not is_httpish(original)
+                    original.startswith("#")
+                    or is_non_fetchable(original)
+                    or not is_httpish(original)
             ):
                 continue
 
@@ -933,9 +934,9 @@ def rewrite_links(
                 url_part = _protocol_fix(parts[0], page_url)
 
                 if (
-                    url_part.startswith("#")
-                    or is_non_fetchable(url_part)
-                    or not is_httpish(url_part)
+                        url_part.startswith("#")
+                        or is_non_fetchable(url_part)
+                        or not is_httpish(url_part)
                 ):
                     new_entries.append(entry)
                     continue
@@ -973,9 +974,9 @@ def rewrite_links(
                     url_part = raw[1:-1].strip()
 
                 if (
-                    not url_part
-                    or url_part.startswith("#")
-                    or url_part.startswith(("data:", "javascript:", "about:"))
+                        not url_part
+                        or url_part.startswith("#")
+                        or url_part.startswith(("data:", "javascript:", "about:"))
                 ):
                     return m.group(0)
 
@@ -1059,12 +1060,12 @@ def extract_css_assets(css_text: str) -> list[str]:
 
 
 def crawl_site(
-    start_url: str,
-    root: Path,
-    max_pages: int,
-    threads: int,
-    download_external_assets: bool = False,
-    external_domains: Optional[set[str]] = None,
+        start_url: str,
+        root: Path,
+        max_pages: int,
+        threads: int,
+        download_external_assets: bool = False,
+        external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Breadth-first crawl limited to max_pages.
@@ -1109,7 +1110,7 @@ def crawl_site(
 
     # Spawn the asset download workers.
     for i in range(max(1, threads)):
-        t = threading.Thread(target=worker, name=f"DL-{i+1}", daemon=True)
+        t = threading.Thread(target=worker, name=f"DL-{i + 1}", daemon=True)
         t.start()
 
     start_time = time.time()
@@ -1143,9 +1144,9 @@ def crawl_site(
 
                 link = _protocol_fix(link_raw, page_url)
                 if (
-                    link.startswith("#")
-                    or is_non_fetchable(link)
-                    or not is_httpish(link)
+                        link.startswith("#")
+                        or is_non_fetchable(link)
+                        or not is_httpish(link)
                 ):
                     continue
 
@@ -1156,9 +1157,9 @@ def crawl_site(
                 # Only crawl internal HTML pages from <a href=...>
                 suffix = Path(parsed.path).suffix.lower()
                 is_page = (
-                    tag.name == "a"
-                    and not is_ext
-                    and (parsed.path.endswith("/") or suffix in PAGE_SUFFIXES)
+                        tag.name == "a"
+                        and not is_ext
+                        and (parsed.path.endswith("/") or suffix in PAGE_SUFFIXES)
                 )
 
                 if is_page:
@@ -1182,7 +1183,7 @@ def crawl_site(
                     # External assets without extensions are only allowed for <script> and <link>
                     # because CDNs sometimes serve JS/CSS without filename extensions.
                     if tag.name not in ("script", "link") and not parsed.path.lower().endswith(
-                        ASSET_EXTENSIONS
+                            ASSET_EXTENSIONS
                     ):
                         continue
 
@@ -1205,9 +1206,9 @@ def crawl_site(
 
                     url_part = _protocol_fix(entry.split()[0], page_url)
                     if (
-                        url_part.startswith("#")
-                        or is_non_fetchable(url_part)
-                        or not is_httpish(url_part)
+                            url_part.startswith("#")
+                            or is_non_fetchable(url_part)
+                            or not is_httpish(url_part)
                     ):
                         continue
 
@@ -1236,11 +1237,11 @@ def crawl_site(
                 for match in CSS_URL_RE.findall(style):
                     url_part = _protocol_fix(match.strip().strip("'\""), page_url)
                     if (
-                        not url_part
-                        or url_part.startswith("#")
-                        or url_part.startswith(("data:", "javascript:", "about:"))
-                        or is_non_fetchable(url_part)
-                        or not is_httpish(url_part)
+                            not url_part
+                            or url_part.startswith("#")
+                            or url_part.startswith(("data:", "javascript:", "about:"))
+                            or is_non_fetchable(url_part)
+                            or not is_httpish(url_part)
                     ):
                         continue
 
@@ -1274,11 +1275,11 @@ def crawl_site(
                 for asset in extract_css_assets(css_text):
                     asset = _protocol_fix(asset, page_url)
                     if (
-                        not asset
-                        or asset.startswith("#")
-                        or asset.startswith(("data:", "javascript:", "about:"))
-                        or is_non_fetchable(asset)
-                        or not is_httpish(asset)
+                            not asset
+                            or asset.startswith("#")
+                            or asset.startswith(("data:", "javascript:", "about:"))
+                            or is_non_fetchable(asset)
+                            or not is_httpish(asset)
                     ):
                         continue
 

--- a/website-downloader.py
+++ b/website-downloader.py
@@ -457,6 +457,7 @@ def rewrite_css_text(
     root_netloc: str,
     base_dir: Path,
     download_external_assets: bool,
+external_domains: Optional[set[str]] = None,
     download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
 ) -> str:
     """
@@ -501,6 +502,9 @@ def rewrite_css_text(
             return None
 
         is_ext = not is_internal(abs_url, root_netloc)
+        if is_ext and not is_allowed_external(abs_url, external_domains):
+            return None
+
         if is_ext and not download_external_assets:
             return None
 
@@ -562,6 +566,7 @@ def rewrite_js_text(
     root_netloc: str,
     base_dir: Path,
     download_external_assets: bool,
+    external_domains: Optional[set[str]] = None,
     download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
 ) -> str:
     """
@@ -594,6 +599,9 @@ def rewrite_js_text(
             return None
 
         is_ext = not is_internal(abs_url, root_netloc)
+        if is_ext and not is_allowed_external(abs_url, external_domains):
+            return None
+
         if is_ext and not download_external_assets:
             return None
 
@@ -679,6 +687,18 @@ def canonicalize_url(url: str, base_url: str = "") -> str:
     return p.geturl()
 
 
+def is_allowed_external(url: str, allowed_domains: Optional[set[str]]) -> bool:
+    if allowed_domains is None:
+        return True
+
+    host = (urlparse(url).hostname or "").lower()
+
+    return any(
+        host == d or host.endswith("." + d)
+        for d in allowed_domains
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fetchers
 # ---------------------------------------------------------------------------
@@ -707,6 +727,7 @@ def fetch_binary(
     site_root: Optional[Path] = None,
     root_netloc: str = "",
     download_external_assets: bool = False,
+    external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Stream a binary/static resource to disk.
@@ -768,6 +789,7 @@ def fetch_binary(
                     root_netloc=root_netloc,
                     base_dir=dest.parent,
                     download_external_assets=download_external_assets,
+                    external_domains=external_domains,
                     download_q=download_q,
                 )
                 if rewritten != css_text:
@@ -792,6 +814,7 @@ def fetch_binary(
                     root_netloc=root_netloc,
                     base_dir=dest.parent,
                     download_external_assets=download_external_assets,
+                    external_domains=external_domains,
                     download_q=download_q,
                 )
                 if rewritten != js_text:
@@ -814,6 +837,7 @@ def rewrite_links(
     site_root: Path,
     page_dir: Path,
     download_external_assets: bool = False,
+    external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Rewrite HTML so it can be opened offline.
@@ -872,8 +896,11 @@ def rewrite_links(
             parsed = urlparse(abs_url)
 
             is_ext = not is_internal(abs_url, root_netloc)
-            if is_ext and not download_external_assets:
-                continue
+            if is_ext:
+                if not download_external_assets:
+                    continue
+                if not is_allowed_external(abs_url, external_domains):
+                    continue
 
             # Treat <a href> as a "page". Everything else is treated as an asset.
             treat_as_page = tag.name == "a" and attr == "href"
@@ -992,7 +1019,8 @@ def rewrite_links(
                 site_root=site_root,
                 root_netloc=root_netloc,
                 base_dir=page_dir,
-                download_external_assets=False,
+                download_external_assets=download_external_assets,
+                external_domains=external_domains,
                 download_q=None,
             )
             if rewritten != css_text:
@@ -1036,6 +1064,7 @@ def crawl_site(
     max_pages: int,
     threads: int,
     download_external_assets: bool = False,
+    external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Breadth-first crawl limited to max_pages.
@@ -1073,6 +1102,7 @@ def crawl_site(
                     site_root=root,
                     root_netloc=root_netloc,
                     download_external_assets=download_external_assets,
+                    external_domains=external_domains,
                 )
             finally:
                 download_q.task_done()
@@ -1139,7 +1169,14 @@ def crawl_site(
 
                 # Otherwise treat it as an asset candidate.
                 if is_ext:
+                    parsed_host = (urlparse(abs_url).hostname or "").lower()
+                    log.info("[EXT-ASSET] %s", parsed_host)
+
                     if not download_external_assets:
+                        continue
+
+                    if not is_allowed_external(abs_url, external_domains):
+                        log.debug("Blocked external (not whitelisted): %s", abs_url)
                         continue
 
                     # External assets without extensions are only allowed for <script> and <link>
@@ -1272,7 +1309,14 @@ def crawl_site(
         # - write out the HTML
         local_path = to_local_path(urlparse(page_url), root)
         create_dir(local_path.parent)
-        rewrite_links(soup, page_url, root, local_path.parent, download_external_assets)
+        rewrite_links(
+            soup,
+            page_url,
+            root,
+            local_path.parent,
+            download_external_assets,
+            external_domains,
+        )
         safe_write_text(local_path, str(soup), encoding="utf-8")
 
     # Wait for all queued asset downloads to finish
@@ -1350,6 +1394,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Download external CDN/static assets and rewrite links for offline use.",
     )
+    p.add_argument(
+        "--external-domains",
+        nargs="+",
+        default=None,
+        help="Whitelist of external domains to download from (implies external download).",
+    )
     return p.parse_args()
 
 
@@ -1367,11 +1417,25 @@ if __name__ == "__main__":
     host = args.url
     root = make_root(args.url, args.destination)
 
+    external_domains = (
+        {
+            urlparse(d).hostname.lower() if "://" in d else d.lower()
+            for d in args.external_domains
+        }
+        if args.external_domains
+        else None
+    )
+
+    download_external_assets = (
+            args.download_external_assets or args.external_domains is not None
+    )
+
     # Kick off crawl
     crawl_site(
         host,
         root,
         args.max_pages,
         args.threads,
-        args.download_external_assets,
+        download_external_assets,
+        external_domains,
     )

--- a/website-downloader.py
+++ b/website-downloader.py
@@ -735,6 +735,17 @@ def fetch_binary(
     - Writes using streaming so we don't keep big files in memory.
     - If the file is CSS or JS, rewrite embedded asset URLs and enqueue them.
     """
+    is_ext = not is_internal(url, root_netloc)
+
+    if is_ext:
+        if not download_external_assets:
+            log.debug("Blocked external (fetch disabled): %s", url)
+            return
+
+        if not is_allowed_external(url, external_domains):
+            log.info("[BLOCKED EXT] %s", url)
+            return
+
     if dest.exists():
         return
 
@@ -1217,8 +1228,14 @@ def crawl_site(
                     if is_ext:
                         if not download_external_assets:
                             continue
+
+                        if not is_allowed_external(abs_url, external_domains):
+                            log.debug("Blocked external (srcset): %s", abs_url)
+                            continue
+
                         if not parsed.path.lower().endswith(ASSET_EXTENSIONS):
                             continue
+
                         dest_path = cdn_local_path(parsed, root)
                     else:
                         dest_path = to_local_asset_path(parsed, root)
@@ -1250,8 +1267,14 @@ def crawl_site(
                         continue
 
                     is_ext = not is_internal(abs_url, root_netloc)
-                    if is_ext and not download_external_assets:
-                        continue
+
+                    if is_ext:
+                        if not download_external_assets:
+                            continue
+
+                        if not is_allowed_external(abs_url, external_domains):
+                            log.debug("Blocked external (inline style): %s", abs_url)
+                            continue
 
                     dest_path = (
                         cdn_local_path(parsed, root)
@@ -1288,8 +1311,14 @@ def crawl_site(
                         continue
 
                     is_ext = not is_internal(abs_url, root_netloc)
-                    if is_ext and not download_external_assets:
-                        continue
+
+                    if is_ext:
+                        if not download_external_assets:
+                            continue
+
+                        if not is_allowed_external(abs_url, external_domains):
+                            log.debug("Blocked external (<style>): %s", abs_url)
+                            continue
 
                     dest_path = (
                         cdn_local_path(parsed, root)

--- a/website-downloader.py
+++ b/website-downloader.py
@@ -451,15 +451,15 @@ def _protocol_fix(url: str, base_url: str) -> str:
 
 
 def rewrite_css_text(
-        css_text: str,
-        base_url: str,
-        *,
-        site_root: Path,
-        root_netloc: str,
-        base_dir: Path,
-        download_external_assets: bool,
-        external_domains: Optional[set[str]] = None,
-        download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
+    css_text: str,
+    base_url: str,
+    *,
+    site_root: Path,
+    root_netloc: str,
+    base_dir: Path,
+    download_external_assets: bool,
+    external_domains: Optional[set[str]] = None,
+    download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
 ) -> str:
     """
     Rewrite CSS url(...) and @import references to local relative paths.
@@ -560,15 +560,15 @@ def rewrite_css_text(
 
 
 def rewrite_js_text(
-        js_text: str,
-        base_url: str,
-        *,
-        site_root: Path,
-        root_netloc: str,
-        base_dir: Path,
-        download_external_assets: bool,
-        external_domains: Optional[set[str]] = None,
-        download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
+    js_text: str,
+    base_url: str,
+    *,
+    site_root: Path,
+    root_netloc: str,
+    base_dir: Path,
+    download_external_assets: bool,
+    external_domains: Optional[set[str]] = None,
+    download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
 ) -> str:
     """
     Rewrite obvious static asset URL strings inside JS.
@@ -655,7 +655,7 @@ def _canonical_netloc(parsed: ParseResult) -> str:
         return parsed.netloc.lower()
 
     if (parsed.scheme == "https" and port == 443) or (
-            parsed.scheme == "http" and port == 80
+        parsed.scheme == "http" and port == 80
     ):
         port = None
 
@@ -694,10 +694,7 @@ def is_allowed_external(url: str, allowed_domains: Optional[set[str]]) -> bool:
 
     host = (urlparse(url).hostname or "").lower()
 
-    return any(
-        host == d or host.endswith("." + d)
-        for d in allowed_domains
-    )
+    return any(host == d or host.endswith("." + d) for d in allowed_domains)
 
 
 # ---------------------------------------------------------------------------
@@ -721,14 +718,14 @@ def fetch_html(url: str) -> Optional[BeautifulSoup]:
 
 
 def fetch_binary(
-        url: str,
-        dest: Path,
-        download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
-        *,
-        site_root: Optional[Path] = None,
-        root_netloc: str = "",
-        download_external_assets: bool = False,
-        external_domains: Optional[set[str]] = None,
+    url: str,
+    dest: Path,
+    download_q: Optional[queue.Queue[tuple[str, Path]]] = None,
+    *,
+    site_root: Optional[Path] = None,
+    root_netloc: str = "",
+    download_external_assets: bool = False,
+    external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Stream a binary/static resource to disk.
@@ -776,10 +773,10 @@ def fetch_binary(
         # If we downloaded CSS, rewrite its url(...) and @import references,
         # and enqueue referenced assets (images/fonts/etc).
         if (
-                dest.suffix.lower() == ".css"
-                and download_q is not None
-                and site_root is not None
-                and root_netloc
+            dest.suffix.lower() == ".css"
+            and download_q is not None
+            and site_root is not None
+            and root_netloc
         ):
             try:
                 css_text = dest.read_text(encoding="utf-8", errors="ignore")
@@ -801,10 +798,10 @@ def fetch_binary(
         # If we downloaded JS, rewrite obvious static URL strings,
         # and enqueue referenced assets (only those matching ASSET_EXTENSIONS).
         if (
-                dest.suffix.lower() in {".js", ".mjs"}
-                and download_q is not None
-                and site_root is not None
-                and root_netloc
+            dest.suffix.lower() in {".js", ".mjs"}
+            and download_q is not None
+            and site_root is not None
+            and root_netloc
         ):
             try:
                 js_text = dest.read_text(encoding="utf-8", errors="ignore")
@@ -833,12 +830,12 @@ def fetch_binary(
 
 
 def rewrite_links(
-        soup: BeautifulSoup,
-        page_url: str,
-        site_root: Path,
-        page_dir: Path,
-        download_external_assets: bool = False,
-        external_domains: Optional[set[str]] = None,
+    soup: BeautifulSoup,
+    page_url: str,
+    site_root: Path,
+    page_dir: Path,
+    download_external_assets: bool = False,
+    external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Rewrite HTML so it can be opened offline.
@@ -870,7 +867,7 @@ def rewrite_links(
                 rel = [rel]
             rel = [r.lower() for r in rel]
             if not any(
-                    r in rel for r in ("stylesheet", "icon", "preload", "modulepreload")
+                r in rel for r in ("stylesheet", "icon", "preload", "modulepreload")
             ):
                 continue
 
@@ -887,9 +884,9 @@ def rewrite_links(
 
             # Skip anchors, non-fetchable schemes, and things that are not http(s)/relative.
             if (
-                    original.startswith("#")
-                    or is_non_fetchable(original)
-                    or not is_httpish(original)
+                original.startswith("#")
+                or is_non_fetchable(original)
+                or not is_httpish(original)
             ):
                 continue
 
@@ -934,9 +931,9 @@ def rewrite_links(
                 url_part = _protocol_fix(parts[0], page_url)
 
                 if (
-                        url_part.startswith("#")
-                        or is_non_fetchable(url_part)
-                        or not is_httpish(url_part)
+                    url_part.startswith("#")
+                    or is_non_fetchable(url_part)
+                    or not is_httpish(url_part)
                 ):
                     new_entries.append(entry)
                     continue
@@ -974,9 +971,9 @@ def rewrite_links(
                     url_part = raw[1:-1].strip()
 
                 if (
-                        not url_part
-                        or url_part.startswith("#")
-                        or url_part.startswith(("data:", "javascript:", "about:"))
+                    not url_part
+                    or url_part.startswith("#")
+                    or url_part.startswith(("data:", "javascript:", "about:"))
                 ):
                     return m.group(0)
 
@@ -1060,12 +1057,12 @@ def extract_css_assets(css_text: str) -> list[str]:
 
 
 def crawl_site(
-        start_url: str,
-        root: Path,
-        max_pages: int,
-        threads: int,
-        download_external_assets: bool = False,
-        external_domains: Optional[set[str]] = None,
+    start_url: str,
+    root: Path,
+    max_pages: int,
+    threads: int,
+    download_external_assets: bool = False,
+    external_domains: Optional[set[str]] = None,
 ) -> None:
     """
     Breadth-first crawl limited to max_pages.
@@ -1144,9 +1141,9 @@ def crawl_site(
 
                 link = _protocol_fix(link_raw, page_url)
                 if (
-                        link.startswith("#")
-                        or is_non_fetchable(link)
-                        or not is_httpish(link)
+                    link.startswith("#")
+                    or is_non_fetchable(link)
+                    or not is_httpish(link)
                 ):
                     continue
 
@@ -1157,9 +1154,9 @@ def crawl_site(
                 # Only crawl internal HTML pages from <a href=...>
                 suffix = Path(parsed.path).suffix.lower()
                 is_page = (
-                        tag.name == "a"
-                        and not is_ext
-                        and (parsed.path.endswith("/") or suffix in PAGE_SUFFIXES)
+                    tag.name == "a"
+                    and not is_ext
+                    and (parsed.path.endswith("/") or suffix in PAGE_SUFFIXES)
                 )
 
                 if is_page:
@@ -1182,9 +1179,10 @@ def crawl_site(
 
                     # External assets without extensions are only allowed for <script> and <link>
                     # because CDNs sometimes serve JS/CSS without filename extensions.
-                    if tag.name not in ("script", "link") and not parsed.path.lower().endswith(
-                            ASSET_EXTENSIONS
-                    ):
+                    if tag.name not in (
+                        "script",
+                        "link",
+                    ) and not parsed.path.lower().endswith(ASSET_EXTENSIONS):
                         continue
 
                     dest_path = cdn_local_path(parsed, root)
@@ -1206,9 +1204,9 @@ def crawl_site(
 
                     url_part = _protocol_fix(entry.split()[0], page_url)
                     if (
-                            url_part.startswith("#")
-                            or is_non_fetchable(url_part)
-                            or not is_httpish(url_part)
+                        url_part.startswith("#")
+                        or is_non_fetchable(url_part)
+                        or not is_httpish(url_part)
                     ):
                         continue
 
@@ -1237,11 +1235,11 @@ def crawl_site(
                 for match in CSS_URL_RE.findall(style):
                     url_part = _protocol_fix(match.strip().strip("'\""), page_url)
                     if (
-                            not url_part
-                            or url_part.startswith("#")
-                            or url_part.startswith(("data:", "javascript:", "about:"))
-                            or is_non_fetchable(url_part)
-                            or not is_httpish(url_part)
+                        not url_part
+                        or url_part.startswith("#")
+                        or url_part.startswith(("data:", "javascript:", "about:"))
+                        or is_non_fetchable(url_part)
+                        or not is_httpish(url_part)
                     ):
                         continue
 
@@ -1275,11 +1273,11 @@ def crawl_site(
                 for asset in extract_css_assets(css_text):
                     asset = _protocol_fix(asset, page_url)
                     if (
-                            not asset
-                            or asset.startswith("#")
-                            or asset.startswith(("data:", "javascript:", "about:"))
-                            or is_non_fetchable(asset)
-                            or not is_httpish(asset)
+                        not asset
+                        or asset.startswith("#")
+                        or asset.startswith(("data:", "javascript:", "about:"))
+                        or is_non_fetchable(asset)
+                        or not is_httpish(asset)
                     ):
                         continue
 
@@ -1428,7 +1426,7 @@ if __name__ == "__main__":
     )
 
     download_external_assets = (
-            args.download_external_assets or args.external_domains is not None
+        args.download_external_assets or args.external_domains is not None
     )
 
     # Kick off crawl


### PR DESCRIPTION
## ✨ Enhancement: External Domain Whitelisting

Adds support for `--external-domains` to enable controlled downloading of external assets via a domain whitelist.

Previously, `--download-external-assets` would fetch assets from **all external domains** (e.g., analytics, third-party widgets, CDNs), introducing unnecessary noise and expanding the download scope.

This update introduces **fine-grained control**, ensuring only explicitly allowed domains are downloaded.

---

## 🔧 What’s Included

- New CLI flag: `--external-domains` (supports multiple domains)
- Whitelist automatically enables external downloads (backward compatible)
- Domain normalization (accepts raw domains or full URLs)
- Centralized filtering via `is_allowed_external()`

---

## 🔒 Enforcement (End-to-End)

Whitelist enforcement is now applied consistently across **all asset ingestion paths**:

- Crawl stage (HTML parsing: `src`, `href`, `data-src`, `poster`)
- `srcset` handling
- Inline styles (`style="url(...)"`)
- `<style>` CSS extraction
- CSS processing (`@import`, `url()`)
- JS asset extraction
- Worker download pipeline (`fetch_binary()` final validation)

👉 A defensive check was added in `fetch_binary()` to prevent any bypass, ensuring no external asset is downloaded unless explicitly allowed.

---

## ✅ Behavior

- Only whitelisted external domains are downloaded
- Non-whitelisted external URLs are skipped (and optionally logged)
- Internal assets continue to work as before
- Existing `--download-external-assets` behavior remains unchanged

---

## 🧪 Validation

- Verified via runtime logs and output directory structure
- Confirmed:
  - ✅ Only allowed domains are downloaded
  - ❌ Non-whitelisted domains are blocked across all paths
  - 🔒 No bypass via `srcset`, inline styles, or `<style>` blocks
  - 🛠️ No runtime or linting issues (Black + Ruff clean)

---

## 💡 Example

```bash
# Only download assets from specific CDN
python3 website-downloader.py --url "https://example.com" \
  --external-domains cdn.prod.website-files.com
  ```
  
  🚀 Outcome
This enhancement provides deterministic and secure external asset handling, making the tool more suitable for:
Offline mirroring
Security analysis
Controlled / restricted environments

📌 Notes
Implements defense-in-depth: validation at both crawl and fetch layers
Eliminates previous edge cases where external assets could bypass filtering

