### PR TITLE
feat: add authenticated crawling support with cookie input and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+example-cookie.txt
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It is designed for clean offline browsing, lab testing, archiving, and migration
 - Optional external asset downloading for CDN/off-site resources
 - Supports domain whitelisting for controlled external downloads
 - Stores external resources under `cdn/<domain>/...`
+- Supports authenticated crawling with `--cookie` and `--cookie-file`
 - Handles protocol-relative URLs like `//cdn.example.com/file.css`
 - Rewrites social preview assets like `og:image` and `twitter:image`
 - Removes problematic `integrity` and `crossorigin` attributes when external assets are localized
@@ -81,7 +82,21 @@ python website-downloader.py \
     --destination example_backup \
     --max-pages 100 \
     --threads 8
+
+# 4. Mirror a protected site using a cookie file
+python website-downloader.py \
+  --url https://intranet.example.com \
+  --destination example_backup \
+  --cookie-file example-cookie.txt
 ```
+
+The sample cookie file uses simple header syntax:
+
+```text
+sessionid=abc123; csrftoken=xyz789
+```
+
+You can rename `example-cookie.txt` to any other file name if you prefer. The downloader reads the cookie values from that file and sends them with the crawl session.
 
 ---
 
@@ -109,6 +124,7 @@ python website-downloader.py \
 | `website-downloader.py` | **Main CLI script** that handles crawling, downloading, and offline link rewriting. | • Shared `requests.Session` with retry and backoff handling<br>• Breadth-first crawl controlled by `--max-pages`<br>• Worker-thread queue for concurrent asset downloads via `--threads`<br>• Rewrites internal links for offline browsing<br>• Supports external asset downloading and domain whitelisting<br>• Handles CSS, inline styles, `srcset`, meta images, and selected JS asset references |
 | `requirements.txt` | Minimal runtime dependency list for the project. | • Includes only core third-party packages needed to run the downloader<br>• Keeps installation simple and lightweight |
 | `web_scraper.log` | Auto-generated runtime log file created during execution. | • Captures crawl progress, warnings, errors, and summary details<br>• Useful for troubleshooting failed downloads or rewrite issues |
+| `example-cookie.txt` | Sample cookie file for authenticated crawling. | • Shows the expected `name=value; name2=value2` format for `--cookie-file` |
 | `README.md` | Project documentation and usage guide. | • Covers installation, usage examples, features, flags, and behavior notes |
 | *(output folder)* | Generated at runtime to store the mirrored website locally. | • Saves HTML pages, internal assets, and optionally external CDN assets<br>• Preserves a browsable offline structure such as `index.html`, subfolders, and `cdn/<domain>/...` paths |
 
@@ -226,6 +242,13 @@ When enabled:
 Added support for `--external-domains` to allow controlled downloading of external assets from approved domains only.
 
 This makes external mirroring more precise and avoids pulling unnecessary third-party content.
+
+### ✅ Authenticated Crawling
+Added optional cookie support so protected pages can be mirrored when you already have a valid session.
+
+- `--cookie NAME=VALUE` accepts one or more cookies directly on the command line
+- `--cookie-file FILE` reads cookies from a file like `example-cookie.txt`
+- Cookie input uses simple header syntax such as `sessionid=abc123; csrftoken=xyz789`
 
 ### ✅ Expanded Rewrite Coverage
 Improved offline rewriting support across more HTML and asset reference types, including:

--- a/example-cookie.txt
+++ b/example-cookie.txt
@@ -1,0 +1,1 @@
+name=value; name2=value2

--- a/website-downloader.py
+++ b/website-downloader.py
@@ -1523,6 +1523,21 @@ def make_root(url: str, custom: Optional[str]) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def parse_cookie_header(cookie_header: str) -> dict[str, str]:
+    """
+    Parse a cookie header string like "key1=val1; key2=val2" into a dict.
+    """
+    cookies: dict[str, str] = {}
+    for part in re.split(r";\s*", cookie_header.strip()):
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError(f"Invalid cookie entry: {part}")
+        name, value = part.split("=", 1)
+        cookies[name.strip()] = value.strip()
+    return cookies
+
+
 def parse_args() -> argparse.Namespace:
     """
     Parse command-line arguments.
@@ -1569,6 +1584,26 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Whitelist of external domains to download from (implies external download).",
     )
+    p.add_argument(
+        "--cookie",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help=(
+            "Set a cookie to send with all requests. "
+            "Repeat for multiple cookies, e.g. --cookie sessionid=abc --cookie csrftoken=xyz."
+        ),
+    )
+    p.add_argument(
+        "--cookie-file",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help=(
+            "Read cookies from a file containing cookie header syntax like "
+            "key1=val1; key2=val2;. Can be repeated."
+        ),
+    )
     return p.parse_args()
 
 
@@ -1598,6 +1633,32 @@ if __name__ == "__main__":
     download_external_assets = (
         args.download_external_assets or args.external_domains is not None
     )
+
+    # Process cookies from command line and cookie files, and add them to the session.
+    if args.cookie or args.cookie_file:
+        cookie_dict: dict[str, str] = {}
+
+        for cookie in args.cookie:
+            try:
+                cookie_dict.update(parse_cookie_header(cookie))
+            except ValueError as exc:
+                log.error("Invalid cookie value: %s", exc)
+                sys.exit(2)
+
+        for cookie_path in args.cookie_file:
+            try:
+                raw = Path(cookie_path).expanduser().read_text(encoding="utf-8").strip()
+            except Exception as exc:
+                log.error("Cannot read cookie file %s: %s", cookie_path, exc)
+                sys.exit(2)
+            try:
+                cookie_dict.update(parse_cookie_header(raw))
+            except ValueError as exc:
+                log.error("Invalid cookie file %s: %s", cookie_path, exc)
+                sys.exit(2)
+
+        SESSION.cookies.update(cookie_dict)
+        log.debug("Added cookies to session: %s", list(cookie_dict.keys()))
 
     # Kick off crawl
     crawl_site(


### PR DESCRIPTION
Dope project, the site I wanted to clone needed me to be signed in so thought this would be handy so you can now:

Add optional cookie-based authentication for protected-site mirroring through --cookie and --cookie-file, so the downloader can reuse an authenticated session while crawling pages and assets. Also update the README with usage guidance and add a sample cookie file so the expected name=value; name2=value2 format is clear.

TL;DR: authenticated crawling + docs + sample cookie file.