### PR TITLE
[codex] Add competitive crawler features

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,37 +47,61 @@ On macOS or Linux, activate the virtual environment with:
 source .venv/bin/activate
 ```
 
+## Install Options
+
+Start with the core install, then add extras only when you need them:
+
+| Install | Use when you want |
+| --- | --- |
+| `pip install -e .` | Normal static-site crawling with `requests` and BeautifulSoup. |
+| `pip install -e ".[dev]"` | Tests, formatting, linting, and local contributor work. |
+| `pip install -e ".[render]"` | Playwright-powered JavaScript rendering with `--render-js` or `--headless`. |
+| `pip install -e ".[ux]"` | Rich-powered terminal progress with `--progress`. |
+
 ## How It Works
 
 ```mermaid
 flowchart TD
-    A["Start with a URL and CLI options"] --> B["Create an HTTP session"]
-    B --> C{"Render JavaScript?"}
-    C -- "No" --> D["Download HTML with requests"]
-    C -- "Yes" --> E["Render page with Playwright"]
-    D --> F["Parse HTML with BeautifulSoup"]
+    A["Start with a URL and CLI options"] --> B["Create session with cookies, headers, retries"]
+    B --> C{"Use sitemap?"}
+    C -- "Yes" --> D["Load sitemap URLs into the page queue"]
+    C -- "No" --> E["Queue the starting URL"]
+    D --> F["Fetch next page"]
     E --> F
-    F --> G["Find page links and asset links"]
-    G --> H{"Same-site page?"}
-    H -- "Yes" --> I["Queue page for crawling"]
-    H -- "No" --> J{"Asset allowed?"}
-    J -- "Yes" --> K["Download asset"]
-    J -- "No" --> L["Keep original reference or skip"]
-    I --> M["Rewrite links for offline browsing"]
-    K --> M
-    L --> M
-    M --> N["Save HTML, CSS, JS, images, fonts, and media"]
-    N --> O["Open the mirror locally"]
+    F --> G{"Update cache says unchanged?"}
+    G -- "Yes" --> H["Reuse saved local file"]
+    G -- "No" --> I{"Render JavaScript?"}
+    I -- "No" --> J["Download HTML with requests"]
+    I -- "Yes" --> K["Render page with Playwright"]
+    J --> L["Parse HTML with BeautifulSoup"]
+    K --> L
+    H --> L
+    L --> M["Find page links and asset links"]
+    M --> N{"Same-site page?"}
+    N -- "Yes" --> O["Queue page for crawling"]
+    N -- "No" --> P{"Asset allowed?"}
+    P -- "Yes" --> Q["Download asset"]
+    P -- "No" --> R["Keep original reference or skip"]
+    O --> S["Rewrite links for offline browsing"]
+    Q --> S
+    R --> S
+    S --> T["Save mirror folder"]
+    T --> U{"Export requested?"}
+    U -- "Zip/WARC" --> V["Write portable archive"]
+    U -- "No" --> W["Open index.html locally"]
+    V --> W
 ```
 
 In plain English:
 
-1. You give the CLI a starting URL.
-2. It downloads or optionally renders each page.
-3. It finds links, images, scripts, stylesheets, fonts, media, and metadata assets.
-4. It follows same-site pages up to your `--max-pages` limit.
-5. It saves assets locally and rewrites references so pages still work offline.
-6. It skips unsafe or non-fetchable links like `mailto:`, `tel:`, `javascript:`, and `data:`.
+1. You give the CLI a starting URL and optional crawl settings.
+2. It can seed pages from `sitemap.xml`, custom headers, cookies, and robots rules.
+3. It downloads or optionally renders each page with Playwright.
+4. It finds links, images, scripts, stylesheets, fonts, media, and metadata assets.
+5. It follows same-site pages up to your `--max-pages` limit.
+6. It saves assets locally and rewrites references so pages still work offline.
+7. With `--update`, unchanged resources can be skipped using cache metadata.
+8. With `--zip-output` or `--warc-output`, the result can also be exported as an archive.
 
 ## Common Commands
 
@@ -197,6 +221,19 @@ website-downloader --url https://example.com --progress
 
 If `rich` is not installed, the crawler falls back to normal logging instead of failing.
 
+## Feature Flags At A Glance
+
+| Flag | What it does | Best for |
+| --- | --- | --- |
+| `--render-js` / `--headless` | Uses Playwright before parsing the page. | React, Vue, Angular, Next.js, and other client-rendered sites. |
+| `--cookie-file` | Sends saved browser/session cookies. | Authorized portals, staging sites, docs behind login. |
+| `--header` | Adds custom request headers. | Bearer tokens, staging headers, API gateway headers. |
+| `--update` | Reuses cache metadata and skips unchanged resources when the server supports it. | Recurring mirrors and archives. |
+| `--sitemap` | Seeds the crawl from `sitemap.xml` or a supplied sitemap. | Faster, more complete discovery. |
+| `--progress` | Shows a Rich terminal progress dashboard when installed. | Long crawls where visibility matters. |
+| `--zip-output` | Exports the mirror folder as a zip. | Sharing, attaching, or storing snapshots. |
+| `--warc-output` | Writes a simple WARC response archive. | Archival workflows and future replay tooling. |
+
 ## What Gets Rewritten
 
 | Source | Rewritten for offline use |
@@ -281,6 +318,10 @@ ruff check .
 | `website_downloader/rewrite.py` | HTML, CSS, JavaScript, and `srcset` reference rewriting. |
 | `website_downloader/paths.py` | Filesystem-safe page, asset, and CDN path mapping. |
 | `website_downloader/render.py` | Optional Playwright page rendering. |
+| `website_downloader/cache.py` | Update-mode metadata for `ETag` and `Last-Modified`. |
+| `website_downloader/sitemap.py` | Sitemap and sitemap-index loading. |
+| `website_downloader/progress.py` | Optional Rich progress dashboard. |
+| `website_downloader/exports.py` | Zip and WARC export helpers. |
 | `tests/` | Local pytest suite with a tiny fixture HTTP server. |
 
 ## Roadmap Ideas

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It is built for developers who want something more modern and hackable than `wge
 | Authenticated snapshots | Reuses cookies for portals, intranets, and staging sites you are allowed to access. |
 | Modern asset handling | Understands `srcset`, `data-src`, `poster`, inline styles, CSS imports, meta images, and common JS asset strings. |
 | Controlled CDN mirroring | Downloads only the external domains you allow into `cdn/<domain>/...`. |
+| Ongoing archives | Uses `ETag` and `Last-Modified` metadata to skip unchanged resources with `--update`. |
+| Portable exports | Can produce zip archives and WARC response archives for sharing or long-term storage. |
 
 ## Quick Start
 
@@ -113,6 +115,31 @@ Cookie files use normal cookie header syntax:
 sessionid=abc123; csrftoken=xyz789
 ```
 
+Send custom headers such as bearer tokens:
+
+```bash
+website-downloader ^
+  --url https://docs.example.com ^
+  --destination docs_backup ^
+  --header "Authorization: Bearer <token>" ^
+  --header "X-Environment: staging"
+```
+
+Use a sitemap as the crawl seed:
+
+```bash
+website-downloader ^
+  --url https://example.com ^
+  --destination example_backup ^
+  --sitemap
+```
+
+Point at a custom sitemap URL or local sitemap file:
+
+```bash
+website-downloader --url https://example.com --sitemap https://example.com/sitemap.xml
+```
+
 Use safer crawl limits:
 
 ```bash
@@ -126,6 +153,25 @@ website-downloader ^
   --user-agent "WebsiteDownloader/0.2"
 ```
 
+Update an existing mirror without re-downloading unchanged resources:
+
+```bash
+website-downloader ^
+  --url https://example.com ^
+  --destination example_backup ^
+  --update
+```
+
+Export a portable zip and WARC archive:
+
+```bash
+website-downloader ^
+  --url https://example.com ^
+  --destination example_backup ^
+  --zip-output example_backup.zip ^
+  --warc-output example_backup.warc
+```
+
 ## JavaScript-Rendered Sites
 
 Some modern sites do not expose their real links and assets until JavaScript runs. For those, install the optional Playwright extra:
@@ -136,7 +182,20 @@ playwright install chromium
 website-downloader --url https://example.com --render-js --max-pages 20
 ```
 
-`--render-js` is optional because it is heavier than the default `requests` + BeautifulSoup path. Use it when a normal crawl only captures an empty app shell or misses important client-rendered links.
+`--headless` is also available as a friendly alias for `--render-js`.
+
+`--render-js` and `--headless` are optional because Playwright is heavier than the default `requests` + BeautifulSoup path. Use them when a normal crawl only captures an empty app shell or misses important client-rendered links.
+
+## Live Progress
+
+Install the optional UX extra for a Rich-powered terminal dashboard:
+
+```bash
+pip install -e ".[ux]"
+website-downloader --url https://example.com --progress
+```
+
+If `rich` is not installed, the crawler falls back to normal logging instead of failing.
 
 ## What Gets Rewritten
 
@@ -179,7 +238,12 @@ Open `index.html` in your browser to browse the mirrored copy.
 - Same-origin recursive crawling.
 - Optional external asset downloading with domain allowlists.
 - Cookie-based authenticated crawling.
+- Custom request headers for bearer tokens and staging environments.
 - Optional JavaScript rendering with Playwright.
+- Sitemap-aware crawl seeding.
+- Incremental update mode using `ETag` and `Last-Modified`.
+- Optional Rich-powered progress dashboard.
+- Zip and WARC output formats.
 - Retry and backoff for unstable requests.
 - Worker-thread asset downloads.
 - Path sanitization for Windows/macOS/Linux.
@@ -224,10 +288,8 @@ ruff check .
 These are natural next steps for making the project more useful to developers:
 
 - `--manifest crawl.json` with pages, assets, status codes, titles, headings, and errors.
-- `--sitemap` support to crawl from `sitemap.xml`.
-- `--header` support for bearer tokens and custom request headers.
-- Incremental update mode using `ETag` and `Last-Modified`.
-- Zip export for portable snapshots.
+- Login-flow recording for complex SSO sites.
+- Stronger WARC metadata and replay compatibility.
 - Visual diff mode for migration and redesign checks.
 
 ## Responsible Use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "ruff>=0.6",
 ]
 render = ["playwright>=1.45"]
+ux = ["rich>=13.7"]
 
 [project.scripts]
 website-downloader = "website_downloader.cli:main"
@@ -67,4 +68,3 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,47 @@ class QuietHandler(SimpleHTTPRequestHandler):
         return
 
 
+class ConditionalHandler(QuietHandler):
+    etag = '"test-etag"'
+
+    def end_headers(self) -> None:
+        if self.path.endswith(".html") or self.path == "/":
+            self.send_header("ETag", self.etag)
+            self.send_header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+        super().end_headers()
+
+    def do_GET(self) -> None:
+        if self.headers.get("If-None-Match") == self.etag:
+            self.send_response(304)
+            self.end_headers()
+            return
+        super().do_GET()
+
+
 @contextmanager
 def serve_directory(directory: Path) -> Iterator[str]:
     cwd = Path.cwd()
     os.chdir(directory)
     server = ThreadingHTTPServer(("127.0.0.1", 0), QuietHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+        os.chdir(cwd)
+
+
+@contextmanager
+def serve_directory_with_handler(
+    directory: Path,
+    handler: type[SimpleHTTPRequestHandler],
+) -> Iterator[str]:
+    cwd = Path.cwd()
+    os.chdir(directory)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -54,6 +90,18 @@ def local_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
         encoding="utf-8",
     )
     (site / "about.html").write_text("<html><body>About</body></html>", encoding="utf-8")
+    (site / "sitemap-only.html").write_text(
+        "<html><body>Only in sitemap</body></html>",
+        encoding="utf-8",
+    )
+    (site / "sitemap.xml").write_text(
+        """
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>/sitemap-only.html</loc></url>
+        </urlset>
+        """,
+        encoding="utf-8",
+    )
     (site / "assets" / "site.css").write_text(
         "@import '/assets/extra.css'; body { background: url('../img/bg.png'); }",
         encoding="utf-8",
@@ -67,4 +115,14 @@ def local_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
         (site / "img" / name).write_bytes(b"png")
 
     with serve_directory(site) as base_url:
+        yield base_url, site
+
+
+@pytest.fixture
+def conditional_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    site = tmp_path / "conditional-site"
+    site.mkdir()
+    (site / "index.html").write_text("<html><body>Cached</body></html>", encoding="utf-8")
+
+    with serve_directory_with_handler(site, ConditionalHandler) as base_url:
         yield base_url, site

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import pytest
 
-from website_downloader.cli import load_cookies, parse_args, parse_cookie_header, validate_args
+from website_downloader.cli import (
+    load_cookies,
+    load_headers,
+    parse_args,
+    parse_cookie_header,
+    parse_header,
+    validate_args,
+)
 
 
 def test_parse_cookie_header_accepts_header_syntax() -> None:
@@ -30,3 +37,16 @@ def test_validate_args_rejects_invalid_limits() -> None:
     args = parse_args(["--url", "https://example.com", "--threads", "0"])
     with pytest.raises(ValueError):
         validate_args(args)
+
+
+def test_parse_header_accepts_authorization_header() -> None:
+    assert parse_header("Authorization: Bearer token") == ("Authorization", "Bearer token")
+
+
+def test_load_headers_uses_last_repeated_header() -> None:
+    assert load_headers(["X-Test: one", "X-Test: two"]) == {"X-Test": "two"}
+
+
+def test_headless_alias_enables_flag() -> None:
+    args = parse_args(["--url", "https://example.com", "--headless"])
+    assert args.headless is True

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from zipfile import ZipFile
 
 from website_downloader.crawler import CrawlOptions, crawl_site
 
@@ -40,3 +41,73 @@ def test_crawl_site_mirrors_local_fixture(local_site, tmp_path: Path) -> None:
     js = (output / "assets" / "app.js").read_text(encoding="utf-8")
     assert "'../img/from-js.png'" in js
     assert "'/api/data'" in js
+
+
+def test_crawl_site_uses_sitemap_seed(local_site, tmp_path: Path) -> None:
+    base_url, _site = local_site
+    output = tmp_path / "mirror"
+
+    crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=2,
+            sitemap="auto",
+        )
+    )
+
+    assert (output / "sitemap-only.html").exists()
+
+
+def test_crawl_site_writes_zip_and_warc_outputs(local_site, tmp_path: Path) -> None:
+    base_url, _site = local_site
+    output = tmp_path / "mirror"
+    zip_path = tmp_path / "mirror.zip"
+    warc_path = tmp_path / "mirror.warc"
+
+    crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=1,
+            zip_output=zip_path,
+            warc_output=warc_path,
+        )
+    )
+
+    assert zip_path.exists()
+    with ZipFile(zip_path) as archive:
+        assert "index.html" in archive.namelist()
+
+    warc_text = warc_path.read_text(encoding="utf-8")
+    assert "WARC/1.1" in warc_text
+    assert "WARC-Type: response" in warc_text
+
+
+def test_update_mode_uses_cache_metadata(conditional_site, tmp_path: Path) -> None:
+    base_url, _site = conditional_site
+    output = tmp_path / "mirror"
+    cache_file = tmp_path / "cache.json"
+
+    first = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=1,
+            update=True,
+            cache_file=cache_file,
+        )
+    )
+    second = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=1,
+            update=True,
+            cache_file=cache_file,
+        )
+    )
+
+    assert first.pages_written == 1
+    assert second.pages_cached == 1
+    assert cache_file.exists()

--- a/website_downloader/cache.py
+++ b/website_downloader/cache.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CacheEntry:
+    url: str
+    path: str
+    kind: str
+    status_code: int
+    etag: str | None = None
+    last_modified: str | None = None
+
+
+class CrawlCache:
+    def __init__(self, entries: dict[str, CacheEntry] | None = None) -> None:
+        self.entries = entries or {}
+
+    @classmethod
+    def load(cls, path: Path) -> CrawlCache:
+        if not path.exists():
+            return cls()
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        entries = {
+            url: CacheEntry(**entry)
+            for url, entry in raw.get("entries", {}).items()
+            if isinstance(entry, dict)
+        }
+        return cls(entries)
+
+    def get(self, url: str) -> CacheEntry | None:
+        return self.entries.get(url)
+
+    def conditional_headers(self, url: str) -> dict[str, str]:
+        entry = self.get(url)
+        if entry is None:
+            return {}
+        headers: dict[str, str] = {}
+        if entry.etag:
+            headers["If-None-Match"] = entry.etag
+        if entry.last_modified:
+            headers["If-Modified-Since"] = entry.last_modified
+        return headers
+
+    def update(
+        self,
+        *,
+        url: str,
+        path: Path,
+        kind: str,
+        status_code: int,
+        response_headers: dict[str, Any],
+    ) -> None:
+        self.entries[url] = CacheEntry(
+            url=url,
+            path=path.as_posix(),
+            kind=kind,
+            status_code=status_code,
+            etag=response_headers.get("ETag"),
+            last_modified=response_headers.get("Last-Modified"),
+        )
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": 1,
+            "entries": {
+                url: asdict(entry)
+                for url, entry in sorted(self.entries.items(), key=lambda item: item[0])
+            },
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/website_downloader/cli.py
+++ b/website_downloader/cli.py
@@ -40,6 +40,17 @@ def parse_cookie_header(cookie_header: str) -> dict[str, str]:
     return cookies
 
 
+def parse_header(header: str) -> tuple[str, str]:
+    if ":" not in header:
+        raise ValueError(f"Invalid header entry: {header}")
+    name, value = header.split(":", 1)
+    name = name.strip()
+    value = value.strip()
+    if not name or not value:
+        raise ValueError(f"Invalid header entry: {header}")
+    return name, value
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Recursively mirror a website for offline use.",
@@ -79,6 +90,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Read cookies from a file containing cookie header syntax.",
     )
     parser.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        metavar="NAME: VALUE",
+        help="Add a custom HTTP header. Can be repeated, e.g. --header 'Authorization: Bearer ...'.",
+    )
+    parser.add_argument(
         "--delay", type=float, default=0.0, help="Delay in seconds between page fetches."
     )
     parser.add_argument(
@@ -101,6 +119,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Render pages with Playwright before parsing. Requires the render extra.",
     )
     parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Alias for --render-js. Uses headless Playwright rendering.",
+    )
+    parser.add_argument(
         "--render-wait-until",
         choices=["commit", "domcontentloaded", "load", "networkidle"],
         default="networkidle",
@@ -111,6 +134,42 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=30000,
         help="Playwright navigation timeout for --render-js.",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Use ETag/Last-Modified cache metadata to skip unchanged resources.",
+    )
+    parser.add_argument(
+        "--cache-file",
+        type=Path,
+        default=None,
+        help="Path to the update metadata cache. Defaults to DESTINATION/.website-downloader-cache.json.",
+    )
+    parser.add_argument(
+        "--sitemap",
+        nargs="?",
+        const="auto",
+        default=None,
+        metavar="URL_OR_FILE",
+        help="Seed the crawl from sitemap.xml. Omit the value to use /sitemap.xml.",
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Show a live Rich progress dashboard when the ux extra is installed.",
+    )
+    parser.add_argument(
+        "--zip-output",
+        type=Path,
+        default=None,
+        help="Write the finished mirror to a zip archive.",
+    )
+    parser.add_argument(
+        "--warc-output",
+        type=Path,
+        default=None,
+        help="Write downloaded resources to a simple WARC 1.1 response archive.",
     )
     return parser.parse_args(argv)
 
@@ -127,6 +186,14 @@ def load_cookies(cookie_values: list[str], cookie_files: list[str]) -> dict[str,
     return cookie_dict
 
 
+def load_headers(header_values: list[str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for header in header_values:
+        name, value = parse_header(header)
+        headers[name] = value
+    return headers
+
+
 def validate_args(args: argparse.Namespace) -> None:
     if args.max_pages < 1:
         raise ValueError("--max-pages must be >= 1")
@@ -138,6 +205,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--max-asset-bytes must be >= 1")
     if args.render_timeout_ms < 1:
         raise ValueError("--render-timeout-ms must be >= 1")
+    if args.cache_file is not None and not args.update:
+        raise ValueError("--cache-file requires --update")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -146,11 +215,13 @@ def main(argv: list[str] | None = None) -> int:
     try:
         validate_args(args)
         cookies = load_cookies(args.cookie, args.cookie_file)
+        headers = load_headers(args.header)
     except (OSError, ValueError) as exc:
         log.error("%s", exc)
         return 2
 
     download_external_assets = args.download_external_assets or args.external_domains is not None
+    render_js = args.render_js or args.headless
     options = CrawlOptions(
         start_url=args.url,
         root=make_root(args.url, args.destination),
@@ -159,13 +230,20 @@ def main(argv: list[str] | None = None) -> int:
         download_external_assets=download_external_assets,
         external_domains=normalize_external_domains(args.external_domains),
         cookies=cookies,
+        headers=headers,
         delay=args.delay,
         max_asset_bytes=args.max_asset_bytes,
         user_agent=args.user_agent,
         respect_robots=args.respect_robots,
-        render_js=args.render_js,
+        render_js=render_js,
         render_wait_until=args.render_wait_until,
         render_timeout_ms=args.render_timeout_ms,
+        update=args.update,
+        cache_file=args.cache_file,
+        sitemap=args.sitemap,
+        progress=args.progress,
+        zip_output=args.zip_output,
+        warc_output=args.warc_output,
     )
     crawl_site(options)
     return 0

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -9,11 +9,15 @@ from pathlib import Path
 from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
 
+from .cache import CrawlCache
 from .constants import ASSET_EXTENSIONS, DEFAULT_USER_AGENT, TIMEOUT
+from .exports import SavedResource, create_zip_archive, write_warc
 from .http import create_session, fetch_binary, fetch_html
 from .paths import cdn_local_path, create_dir, safe_write_text, to_local_asset_path, to_local_path
+from .progress import create_progress_reporter
 from .render import PlaywrightRenderer
 from .rewrite import extract_css_assets, link_rel_is_fetchable, rewrite_links
+from .sitemap import load_sitemap_urls
 from .urltools import (
     canonical_netloc,
     canonicalize_url,
@@ -39,6 +43,7 @@ class CrawlOptions:
     download_external_assets: bool = False
     external_domains: set[str] | None = None
     cookies: dict[str, str] | None = None
+    headers: dict[str, str] | None = None
     timeout: int = TIMEOUT
     delay: float = 0.0
     max_asset_bytes: int | None = None
@@ -47,6 +52,12 @@ class CrawlOptions:
     render_js: bool = False
     render_wait_until: str = "networkidle"
     render_timeout_ms: int = 30000
+    update: bool = False
+    cache_file: Path | None = None
+    sitemap: str | None = None
+    progress: bool = False
+    zip_output: Path | None = None
+    warc_output: Path | None = None
 
 
 @dataclass
@@ -54,25 +65,43 @@ class CrawlStats:
     pages_seen: int
     assets_queued: int
     elapsed_seconds: float
+    pages_cached: int = 0
+    assets_cached: int = 0
+    pages_written: int = 0
+    assets_written: int = 0
 
 
 def crawl_site(options: CrawlOptions) -> CrawlStats:
     q_pages: queue.Queue[str] = queue.Queue()
     start_url = canonicalize_url(options.start_url)
-    q_pages.put(start_url)
-
     seen_pages: set[str] = set()
-    queued_pages: set[str] = {start_url}
+    queued_pages: set[str] = set()
     queued_assets: set[str] = set()
     asset_lock = threading.Lock()
+    cache_lock = threading.Lock()
+    record_lock = threading.Lock()
     download_q: queue.Queue[tuple[str, Path] | None] = queue.Queue()
+    saved_records: list[SavedResource] = []
 
     root_netloc = canonical_netloc(urlparse(start_url))
     user_agent = options.user_agent or DEFAULT_USER_AGENT
-    page_session = create_session(user_agent=user_agent, cookies=options.cookies)
+    page_session = create_session(
+        user_agent=user_agent,
+        cookies=options.cookies,
+        headers=options.headers,
+    )
     robots = (
         _load_robots(start_url, page_session, options.timeout) if options.respect_robots else None
     )
+    cache_path = options.cache_file or (options.root / ".website-downloader-cache.json")
+    crawl_cache = CrawlCache.load(cache_path) if options.update else CrawlCache()
+    stats = CrawlStats(pages_seen=0, assets_queued=0, elapsed_seconds=0.0)
+
+    def enqueue_page(url: str) -> None:
+        normalized = normalize_url(canonicalize_url(url, start_url))
+        if normalized not in queued_pages and normalized not in seen_pages:
+            q_pages.put(normalized)
+            queued_pages.add(normalized)
 
     def enqueue_asset(url: str, dest: Path) -> None:
         abs_url = normalize_url(canonicalize_url(url))
@@ -80,24 +109,29 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
             if abs_url in queued_assets:
                 return
             queued_assets.add(abs_url)
+            stats.assets_queued = len(queued_assets)
+        progress_reporter.asset_queued()
         create_dir(dest.parent)
         log.debug("Queue asset: %s -> %s", abs_url, dest)
         download_q.put((abs_url, dest))
 
-    workers = _start_workers(
-        threads=options.threads,
-        download_q=download_q,
-        enqueue_asset=enqueue_asset,
-        options=options,
-        root_netloc=root_netloc,
-        user_agent=user_agent,
-    )
+    enqueue_page(start_url)
+    if options.sitemap:
+        for sitemap_url in load_sitemap_urls(
+            options.sitemap,
+            start_url=start_url,
+            session=page_session,
+            timeout=options.timeout,
+            root_netloc=root_netloc,
+        ):
+            enqueue_page(sitemap_url)
 
     start_time = time.time()
     renderer_context = (
         PlaywrightRenderer(
             start_url=start_url,
             cookies=options.cookies,
+            headers=options.headers,
             timeout_ms=options.render_timeout_ms,
             wait_until=options.render_wait_until,
             user_agent=user_agent,
@@ -105,9 +139,28 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
         if options.render_js
         else None
     )
+    progress_reporter = create_progress_reporter(options.progress, options.max_pages)
+    workers: list[threading.Thread] = []
 
     try:
-        with _optional_renderer(renderer_context) as renderer:
+        with (
+            _optional_renderer(renderer_context) as renderer,
+            progress_reporter as progress,
+        ):
+            workers = _start_workers(
+                threads=options.threads,
+                download_q=download_q,
+                enqueue_asset=enqueue_asset,
+                options=options,
+                root_netloc=root_netloc,
+                user_agent=user_agent,
+                cache=crawl_cache,
+                cache_lock=cache_lock,
+                records=saved_records,
+                record_lock=record_lock,
+                stats=stats,
+                progress=progress,
+            )
             while not q_pages.empty() and len(seen_pages) < options.max_pages:
                 page_url = canonicalize_url(q_pages.get())
                 if page_url in seen_pages:
@@ -117,19 +170,27 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                     continue
 
                 seen_pages.add(page_url)
+                stats.pages_seen = len(seen_pages)
                 log.info("[%s/%s] %s", len(seen_pages), options.max_pages, page_url)
+                progress.page_seen(len(seen_pages), options.max_pages, page_url)
 
+                local_path = to_local_path(urlparse(page_url), options.root)
                 soup = fetch_html(
                     page_url,
                     session=page_session,
                     timeout=options.timeout,
                     renderer=renderer,
+                    conditional_headers=(
+                        crawl_cache.conditional_headers(page_url) if options.update else None
+                    ),
+                    cached_path=local_path,
                 )
-                if soup is None:
+                if soup is None or soup.soup is None:
+                    progress.error()
                     continue
 
                 _discover_references(
-                    soup,
+                    soup.soup,
                     page_url=page_url,
                     root=options.root,
                     root_netloc=root_netloc,
@@ -140,17 +201,41 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                     options=options,
                 )
 
-                local_path = to_local_path(urlparse(page_url), options.root)
-                create_dir(local_path.parent)
-                rewrite_links(
-                    soup,
-                    page_url,
-                    options.root,
-                    local_path.parent,
-                    options.download_external_assets,
-                    options.external_domains,
-                )
-                safe_write_text(local_path, str(soup), encoding="utf-8")
+                if soup.not_modified:
+                    stats.pages_cached += 1
+                    progress.page_saved(cached=True)
+                else:
+                    create_dir(local_path.parent)
+                    rewrite_links(
+                        soup.soup,
+                        page_url,
+                        options.root,
+                        local_path.parent,
+                        options.download_external_assets,
+                        options.external_domains,
+                    )
+                    safe_write_text(local_path, str(soup.soup), encoding="utf-8")
+                    stats.pages_written += 1
+                    progress.page_saved()
+                    if options.update:
+                        with cache_lock:
+                            crawl_cache.update(
+                                url=page_url,
+                                path=local_path,
+                                kind="page",
+                                status_code=soup.status_code,
+                                response_headers=soup.headers,
+                            )
+                    with record_lock:
+                        saved_records.append(
+                            SavedResource(
+                                url=page_url,
+                                path=local_path,
+                                kind="page",
+                                status_code=soup.status_code,
+                                content_type=soup.content_type or "text/html",
+                            )
+                        )
 
                 if options.delay:
                     time.sleep(options.delay)
@@ -163,6 +248,7 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
             worker.join(timeout=5)
 
     elapsed = time.time() - start_time
+    stats.elapsed_seconds = elapsed
     if seen_pages:
         log.info(
             "Crawl finished: %s pages in %.2fs (%.2fs avg)",
@@ -173,11 +259,16 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
     else:
         log.warning("Nothing downloaded; check URL or connectivity")
 
-    return CrawlStats(
-        pages_seen=len(seen_pages),
-        assets_queued=len(queued_assets),
-        elapsed_seconds=elapsed,
-    )
+    if options.update:
+        crawl_cache.save(cache_path)
+    if options.zip_output is not None:
+        create_zip_archive(options.root, options.zip_output)
+        log.info("Wrote zip archive: %s", options.zip_output)
+    if options.warc_output is not None:
+        write_warc(saved_records, options.warc_output)
+        log.info("Wrote WARC archive: %s", options.warc_output)
+
+    return stats
 
 
 class _optional_renderer:
@@ -203,16 +294,26 @@ def _start_workers(
     options: CrawlOptions,
     root_netloc: str,
     user_agent: str,
+    cache: CrawlCache,
+    cache_lock: threading.Lock,
+    records: list[SavedResource],
+    record_lock: threading.Lock,
+    stats: CrawlStats,
+    progress,
 ) -> list[threading.Thread]:
     def worker() -> None:
-        session = create_session(user_agent=user_agent, cookies=options.cookies)
+        session = create_session(
+            user_agent=user_agent,
+            cookies=options.cookies,
+            headers=options.headers,
+        )
         while True:
             item = download_q.get()
             try:
                 if item is None:
                     return
                 url, dest = item
-                fetch_binary(
+                result = fetch_binary(
                     url,
                     dest,
                     session=session,
@@ -223,7 +324,37 @@ def _start_workers(
                     timeout=options.timeout,
                     max_asset_bytes=options.max_asset_bytes,
                     enqueue_asset=enqueue_asset,
+                    update=options.update,
+                    conditional_headers=cache.conditional_headers(url) if options.update else None,
                 )
+                if result is None:
+                    progress.error()
+                    continue
+                if result.not_modified:
+                    stats.assets_cached += 1
+                    progress.asset_saved(cached=True)
+                    continue
+                stats.assets_written += 1
+                progress.asset_saved()
+                if options.update:
+                    with cache_lock:
+                        cache.update(
+                            url=url,
+                            path=result.path,
+                            kind="asset",
+                            status_code=result.status_code,
+                            response_headers=result.headers,
+                        )
+                with record_lock:
+                    records.append(
+                        SavedResource(
+                            url=url,
+                            path=result.path,
+                            kind="asset",
+                            status_code=result.status_code,
+                            content_type=result.content_type,
+                        )
+                    )
             finally:
                 download_q.task_done()
 

--- a/website_downloader/exports.py
+++ b/website_downloader/exports.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+from zipfile import ZIP_DEFLATED, ZipFile
+
+
+@dataclass
+class SavedResource:
+    url: str
+    path: Path
+    kind: str
+    status_code: int
+    content_type: str | None = None
+
+
+def create_zip_archive(root: Path, zip_path: Path) -> None:
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_zip = zip_path.resolve()
+    with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as archive:
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.resolve() == resolved_zip:
+                continue
+            archive.write(path, path.relative_to(root).as_posix())
+
+
+def write_warc(records: list[SavedResource], warc_path: Path) -> None:
+    warc_path.parent.mkdir(parents=True, exist_ok=True)
+    with warc_path.open("wb") as file:
+        for record in records:
+            if not record.path.exists():
+                continue
+            payload = record.path.read_bytes()
+            http_block = _http_response_block(record, payload)
+            warc_header = _warc_header(record, len(http_block))
+            file.write(warc_header)
+            file.write(http_block)
+            file.write(b"\r\n\r\n")
+
+
+def _http_response_block(record: SavedResource, payload: bytes) -> bytes:
+    content_type = record.content_type or "application/octet-stream"
+    headers = (
+        f"HTTP/1.1 {record.status_code} OK\r\n"
+        f"Content-Type: {content_type}\r\n"
+        f"Content-Length: {len(payload)}\r\n"
+        "\r\n"
+    ).encode()
+    return headers + payload
+
+
+def _warc_header(record: SavedResource, content_length: int) -> bytes:
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    header = (
+        "WARC/1.1\r\n"
+        "WARC-Type: response\r\n"
+        f"WARC-Target-URI: {record.url}\r\n"
+        f"WARC-Date: {now}\r\n"
+        f"WARC-Record-ID: <urn:uuid:{uuid4()}>\r\n"
+        "Content-Type: application/http; msgtype=response\r\n"
+        f"Content-Length: {content_length}\r\n"
+        f"WARC-Profile: {record.kind}\r\n"
+        "\r\n"
+    )
+    return header.encode("utf-8")

--- a/website_downloader/http.py
+++ b/website_downloader/http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 import requests
@@ -16,10 +17,29 @@ from .urltools import is_allowed_external, is_httpish, is_internal, is_non_fetch
 log = logging.getLogger(__name__)
 
 
+@dataclass
+class HtmlFetchResult:
+    soup: BeautifulSoup | None
+    status_code: int
+    headers: dict[str, str]
+    not_modified: bool = False
+    content_type: str | None = None
+
+
+@dataclass
+class BinaryFetchResult:
+    path: Path
+    status_code: int
+    headers: dict[str, str]
+    not_modified: bool = False
+    content_type: str | None = None
+
+
 def create_session(
     *,
     user_agent: str | None = None,
     cookies: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> requests.Session:
     session = requests.Session()
     retry_strategy = Retry(
@@ -34,6 +54,8 @@ def create_session(
     session.headers.update(DEFAULT_HEADERS)
     if user_agent:
         session.headers["User-Agent"] = user_agent
+    if headers:
+        session.headers.update(headers)
     if cookies:
         session.cookies.update(cookies)
     log.debug("Accept-Encoding configured as: %s", session.headers.get("Accept-Encoding"))
@@ -46,13 +68,36 @@ def fetch_html(
     session: requests.Session,
     timeout: int = TIMEOUT,
     renderer=None,
-) -> BeautifulSoup | None:
+    conditional_headers: dict[str, str] | None = None,
+    cached_path: Path | None = None,
+) -> HtmlFetchResult | None:
     try:
         if renderer is not None:
-            return BeautifulSoup(renderer.fetch(url), "html.parser")
-        response = session.get(url, timeout=timeout)
+            html = renderer.fetch(url)
+            return HtmlFetchResult(
+                soup=BeautifulSoup(html, "html.parser"),
+                status_code=200,
+                headers={},
+                content_type="text/html",
+            )
+        response = session.get(url, timeout=timeout, headers=conditional_headers)
+        headers = dict(response.headers)
+        if response.status_code == 304:
+            soup = _read_cached_html(cached_path)
+            return HtmlFetchResult(
+                soup=soup,
+                status_code=304,
+                headers=headers,
+                not_modified=True,
+                content_type=response.headers.get("Content-Type"),
+            )
         response.raise_for_status()
-        return BeautifulSoup(response.text, "html.parser")
+        return HtmlFetchResult(
+            soup=BeautifulSoup(response.text, "html.parser"),
+            status_code=response.status_code,
+            headers=headers,
+            content_type=response.headers.get("Content-Type"),
+        )
     except Exception as exc:
         log.warning("HTTP error for %s: %s", url, exc)
         return None
@@ -70,7 +115,9 @@ def fetch_binary(
     timeout: int = TIMEOUT,
     max_asset_bytes: int | None = None,
     enqueue_asset: EnqueueAsset | None = None,
-) -> None:
+    update: bool = False,
+    conditional_headers: dict[str, str] | None = None,
+) -> BinaryFetchResult | None:
     is_ext = not is_internal(url, root_netloc)
     if is_ext and not download_external_assets:
         log.debug("Blocked external asset because external downloads are disabled: %s", url)
@@ -80,16 +127,25 @@ def fetch_binary(
         return
     if is_non_fetchable(url) or not is_httpish(url):
         log.debug("Skipping non-fetchable URL: %s", url)
-        return
-    if dest.exists():
-        return
+        return None
+    if dest.exists() and not update:
+        return None
 
     try:
-        response = session.get(url, timeout=timeout, stream=True)
+        response = session.get(url, timeout=timeout, stream=True, headers=conditional_headers)
+        headers = dict(response.headers)
+        if response.status_code == 304 and dest.exists():
+            return BinaryFetchResult(
+                path=dest,
+                status_code=304,
+                headers=headers,
+                not_modified=True,
+                content_type=response.headers.get("Content-Type"),
+            )
         response.raise_for_status()
         if _too_large(response, max_asset_bytes):
             log.warning("Skipping asset over size limit: %s", url)
-            return
+            return None
 
         create_dir(dest.parent)
         final_dest = _write_stream(response, dest, max_asset_bytes=max_asset_bytes)
@@ -116,8 +172,21 @@ def fetch_binary(
                 external_domains=external_domains,
                 enqueue_asset=enqueue_asset,
             )
+        return BinaryFetchResult(
+            path=final_dest,
+            status_code=response.status_code,
+            headers=headers,
+            content_type=response.headers.get("Content-Type"),
+        )
     except Exception as exc:
         log.error("Failed to save %s: %s", url, exc)
+        return None
+
+
+def _read_cached_html(cached_path: Path | None) -> BeautifulSoup | None:
+    if cached_path is None or not cached_path.exists():
+        return None
+    return BeautifulSoup(cached_path.read_text(encoding="utf-8", errors="ignore"), "html.parser")
 
 
 def _too_large(response: requests.Response, max_asset_bytes: int | None) -> bool:

--- a/website_downloader/progress.py
+++ b/website_downloader/progress.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+from types import TracebackType
+
+log = logging.getLogger(__name__)
+
+
+class ProgressReporter:
+    def __enter__(self) -> ProgressReporter:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def page_seen(self, current: int, total: int, url: str) -> None:
+        return None
+
+    def page_saved(self, cached: bool = False) -> None:
+        return None
+
+    def asset_queued(self) -> None:
+        return None
+
+    def asset_saved(self, cached: bool = False) -> None:
+        return None
+
+    def error(self) -> None:
+        return None
+
+
+class RichProgressReporter(ProgressReporter):
+    def __init__(self, max_pages: int) -> None:
+        from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+        self.progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            TextColumn("{task.completed}/{task.total} pages"),
+            TextColumn("assets {task.fields[assets_saved]}/{task.fields[assets_queued]}"),
+            TextColumn("cached {task.fields[cached]}"),
+            TimeElapsedColumn(),
+        )
+        self.task_id = self.progress.add_task(
+            "Mirroring",
+            total=max_pages,
+            assets_queued=0,
+            assets_saved=0,
+            cached=0,
+        )
+        self.assets_queued = 0
+        self.assets_saved = 0
+        self.pages_cached = 0
+
+    def __enter__(self) -> RichProgressReporter:
+        self.progress.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.progress.__exit__(exc_type, exc, tb)
+
+    def page_seen(self, current: int, total: int, url: str) -> None:
+        self.progress.update(
+            self.task_id,
+            completed=max(0, current - 1),
+            description=f"Mirroring {url}",
+            total=total,
+        )
+
+    def page_saved(self, cached: bool = False) -> None:
+        if cached:
+            self.pages_cached += 1
+            self._refresh_fields()
+        self.progress.advance(self.task_id)
+
+    def asset_queued(self) -> None:
+        self.assets_queued += 1
+        self._refresh_fields()
+
+    def asset_saved(self, cached: bool = False) -> None:
+        self.assets_saved += 1
+        if cached:
+            self.pages_cached += 1
+        self._refresh_fields()
+
+    def _refresh_fields(self) -> None:
+        self.progress.update(
+            self.task_id,
+            assets_queued=self.assets_queued,
+            assets_saved=self.assets_saved,
+            cached=self.pages_cached,
+        )
+
+
+def create_progress_reporter(enabled: bool, max_pages: int) -> ProgressReporter:
+    if not enabled:
+        return ProgressReporter()
+    try:
+        return RichProgressReporter(max_pages)
+    except ImportError:
+        log.warning("Install the ux extra to use --progress: pip install -e .[ux]")
+        return ProgressReporter()

--- a/website_downloader/render.py
+++ b/website_downloader/render.py
@@ -14,12 +14,14 @@ class PlaywrightRenderer:
         *,
         start_url: str,
         cookies: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout_ms: int = 30000,
         wait_until: str = "networkidle",
         user_agent: str | None = None,
     ) -> None:
         self.start_url = start_url
         self.cookies = cookies or {}
+        self.headers = headers or {}
         self.timeout_ms = timeout_ms
         self.wait_until = wait_until
         self.user_agent = user_agent or DEFAULT_USER_AGENT
@@ -38,7 +40,10 @@ class PlaywrightRenderer:
 
         self._playwright = sync_playwright().start()
         self._browser = self._playwright.chromium.launch(headless=True)
-        self._context = self._browser.new_context(user_agent=self.user_agent)
+        self._context = self._browser.new_context(
+            user_agent=self.user_agent,
+            extra_http_headers=self.headers or None,
+        )
         self._add_cookies()
         return self
 

--- a/website_downloader/sitemap.py
+++ b/website_downloader/sitemap.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from urllib.parse import urlparse
+from xml.etree import ElementTree
+
+import requests
+
+from .urltools import canonicalize_url, is_internal
+
+log = logging.getLogger(__name__)
+
+
+def load_sitemap_urls(
+    sitemap: str,
+    *,
+    start_url: str,
+    session: requests.Session,
+    timeout: int,
+    root_netloc: str,
+) -> list[str]:
+    sitemap_url = _resolve_sitemap_location(sitemap, start_url)
+    seen_sitemaps: set[str] = set()
+    return _load_sitemap_urls(
+        sitemap_url,
+        session=session,
+        timeout=timeout,
+        root_netloc=root_netloc,
+        seen_sitemaps=seen_sitemaps,
+    )
+
+
+def _resolve_sitemap_location(sitemap: str, start_url: str) -> str:
+    if sitemap == "auto":
+        parsed = urlparse(start_url)
+        return f"{parsed.scheme}://{parsed.netloc}/sitemap.xml"
+    return sitemap
+
+
+def _load_sitemap_urls(
+    sitemap: str,
+    *,
+    session: requests.Session,
+    timeout: int,
+    root_netloc: str,
+    seen_sitemaps: set[str],
+) -> list[str]:
+    if sitemap in seen_sitemaps:
+        return []
+    seen_sitemaps.add(sitemap)
+
+    try:
+        text = _read_sitemap_text(sitemap, session=session, timeout=timeout)
+        root = ElementTree.fromstring(text)
+    except Exception as exc:
+        log.warning("Could not read sitemap %s: %s", sitemap, exc)
+        return []
+
+    tag = _strip_namespace(root.tag)
+    urls: list[str] = []
+    if tag == "urlset":
+        for loc in root.findall(".//{*}url/{*}loc"):
+            if loc.text:
+                url = canonicalize_url(loc.text.strip(), sitemap)
+                if is_internal(url, root_netloc):
+                    urls.append(url)
+    elif tag == "sitemapindex":
+        for loc in root.findall(".//{*}sitemap/{*}loc"):
+            if loc.text:
+                nested = canonicalize_url(loc.text.strip(), sitemap)
+                urls.extend(
+                    _load_sitemap_urls(
+                        nested,
+                        session=session,
+                        timeout=timeout,
+                        root_netloc=root_netloc,
+                        seen_sitemaps=seen_sitemaps,
+                    )
+                )
+    else:
+        log.warning("Unsupported sitemap root %s in %s", tag, sitemap)
+
+    return list(dict.fromkeys(urls))
+
+
+def _read_sitemap_text(sitemap: str, *, session: requests.Session, timeout: int) -> str:
+    parsed = urlparse(sitemap)
+    if parsed.scheme in {"http", "https"}:
+        response = session.get(sitemap, timeout=timeout)
+        response.raise_for_status()
+        return response.text
+    return Path(sitemap).expanduser().read_text(encoding="utf-8")
+
+
+def _strip_namespace(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]


### PR DESCRIPTION
## Summary

This branch stacks on top of `improve-packaging-tests-js` and adds the market-facing crawler improvements discussed in the roadmap.

- Add `--headless` as a friendly alias for Playwright-backed JavaScript rendering.
- Add repeatable `--header "Name: Value"` support for bearer tokens, staging headers, and other authenticated crawl needs.
- Add `--update` support with ETag/Last-Modified cache metadata so unchanged pages/assets can be skipped on later runs.
- Add `--sitemap [URL_OR_FILE]` crawl seeding, including default `/sitemap.xml` discovery.
- Add optional `--progress` Rich-powered terminal progress support via the new `.[ux]` extra.
- Add `--zip-output` and `--warc-output` export options.
- Document the new commands and expand tests for headers, sitemap crawling, update caching, zip output, and WARC output.

## Review note

This PR currently includes the package-layout foundation from PR #42 because it is stacked on that branch. To review only the market-feature delta, compare:

https://github.com/PKHarsimran/website-downloader/compare/improve-packaging-tests-js...market-competitive-improvements

After PR #42 merges, this PR diff should collapse to only the competitive crawler feature commit.

## Notes

The WARC writer is intentionally lightweight and writes simple WARC 1.1 response records from saved resources. A future branch can deepen replay compatibility and metadata.

## Validation

- `pytest` passed: 23 tests
- `black . --check --diff` passed
- `isort . --check-only --diff` passed
- `ruff check .` passed
- `python website-downloader.py --help` passed
- `git diff --check` passed