### PR TITLE
Fix update-mode bugs, add parallel page fetching, and overhaul README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+# Local mirror output from test runs
+harsim_ca/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `--update` re-crawls no longer discover links from saved pages (whose links are already rewritten to local paths, producing bogus 404 URLs); known pages and assets are re-seeded from the update cache instead.
+- A `304 Not Modified` response with a missing local copy now triggers a clean refetch instead of writing a zero-byte asset or skipping the page.
+- Assets already present on disk are reported as cached instead of counted as errors when re-running into the same folder.
+- CSS `@import url(...)` rules are mapped once; previously the rewritten local path was re-mapped and a garbage download URL was enqueued.
+- The Rich progress dashboard's cached counter now tracks cached pages and assets correctly.
+
+### Changed
+
+- New optional `.[fast]` extra installs lxml for faster HTML parsing; it is auto-detected and used when available.
+- Pages are parsed from raw bytes so BeautifulSoup honors `<meta charset>` declarations and BOMs when servers omit a charset header.
+- `CrawlStats` gained an `errors` counter, and the end-of-crawl summary now reports pages, assets, cache hits, and errors.
+- Removed redundant URL re-parsing in the link discovery hot path and no longer pre-creates directories for queued assets (avoids empty folders for failed downloads).
+
 ## v2.5.0 - 2026-06-28
 
 This release turns Website Downloader CLI into a more complete modern-site mirroring tool while keeping the default install lightweight and developer-friendly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `--page-threads` fetches HTML pages concurrently (default 1 keeps the previous polite sequential behavior). Roughly 3-4x faster on multi-page sites with 4 workers. `--render-js` always uses a single page worker because Playwright's sync API is single-threaded.
+
 ### Fixed
 
 - `--update` re-crawls no longer discover links from saved pages (whose links are already rewritten to local paths, producing bogus 404 URLs); known pages and assets are re-seeded from the update cache instead.
@@ -15,6 +19,7 @@
 - New optional `.[fast]` extra installs lxml for faster HTML parsing; it is auto-detected and used when available.
 - Pages are parsed from raw bytes so BeautifulSoup honors `<meta charset>` declarations and BOMs when servers omit a charset header.
 - `CrawlStats` gained an `errors` counter, and the end-of-crawl summary now reports pages, assets, cache hits, and errors.
+- A page that fails mid-processing is now logged and counted as an error instead of aborting the whole crawl.
 - Removed redundant URL re-parsing in the link discovery hot path and no longer pre-creates directories for queued assets (avoids empty folders for failed downloads).
 
 ## v2.5.0 - 2026-06-28

--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ website-downloader ^
   --user-agent "WebsiteDownloader/0.2"
 ```
 
+Speed up a large mirror with parallel page fetching:
+
+```bash
+website-downloader ^
+  --url https://example.com ^
+  --max-pages 500 ^
+  --page-threads 4
+```
+
+`--page-threads` defaults to 1 so crawls stay polite; raise it only for sites that can handle concurrent requests. `--render-js` always uses a single page worker.
+
 Update an existing mirror without re-downloading unchanged resources:
 
 ```bash
@@ -229,6 +240,7 @@ If `rich` is not installed, the crawler falls back to normal logging instead of 
 | `--render-js` / `--headless` | Uses Playwright before parsing the page. | React, Vue, Angular, Next.js, and other client-rendered sites. |
 | `--cookie-file` | Sends saved browser/session cookies. | Authorized portals, staging sites, docs behind login. |
 | `--header` | Adds custom request headers. | Bearer tokens, staging headers, API gateway headers. |
+| `--page-threads` | Fetches HTML pages concurrently (default 1). | Faster mirroring of large sites that tolerate concurrent requests. |
 | `--update` | Reuses cache metadata and skips unchanged resources when the server supports it. | Recurring mirrors and archives. |
 | `--sitemap` | Seeds the crawl from `sitemap.xml` or a supplied sitemap. | Faster, more complete discovery. |
 | `--progress` | Shows a Rich terminal progress dashboard when installed. | Long crawls where visibility matters. |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Start with the core install, then add extras only when you need them:
 | --- | --- |
 | `pip install -e .` | Normal static-site crawling with `requests` and BeautifulSoup. |
 | `pip install -e ".[dev]"` | Tests, formatting, linting, and local contributor work. |
+| `pip install -e ".[fast]"` | Faster HTML parsing with lxml (used automatically when installed). |
 | `pip install -e ".[render]"` | Playwright-powered JavaScript rendering with `--render-js` or `--headless`. |
 | `pip install -e ".[ux]"` | Rich-powered terminal progress with `--progress`. |
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,81 @@
-# Website Downloader CLI
+<div align="center">
+
+# 🌐 Website Downloader CLI
+
+**Turn any website you're authorized to copy into a fast, browsable offline mirror — with one command.**
 
 [![CI - Website Downloader](https://github.com/PKHarsimran/website-downloader/actions/workflows/python-app.yml/badge.svg)](https://github.com/PKHarsimran/website-downloader/actions/workflows/python-app.yml)
 [![Lint & Style](https://github.com/PKHarsimran/website-downloader/actions/workflows/lint.yml/badge.svg)](https://github.com/PKHarsimran/website-downloader/actions/workflows/lint.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Last Commit](https://img.shields.io/github/last-commit/PKHarsimran/website-downloader)](https://github.com/PKHarsimran/website-downloader/commits/main)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/PKHarsimran/website-downloader/pulls)
 
-Website Downloader CLI turns a public or authorized website into a browsable offline copy. It crawls pages, downloads assets, rewrites links, and saves everything into a local folder you can open, inspect, archive, or move into a migration workflow.
+*A modern, hackable alternative to `wget --mirror` and HTTrack — built in pure Python, without dragging in a heavy crawler framework.*
 
-It is built for developers who want something more modern and hackable than `wget --mirror`, without jumping straight into a heavy crawler framework.
+</div>
 
-## Why Use It
+---
 
-| Need | What this tool gives you |
-| --- | --- |
-| Offline browsing | Saves HTML pages and local asset references that work from disk. |
-| Migration prep | Captures the old site before a rebuild, redesign, or host move. |
-| Static-site review | Lets you inspect pages, CSS, JS, images, fonts, and media locally. |
-| Authenticated snapshots | Reuses cookies for portals, intranets, and staging sites you are allowed to access. |
-| Modern asset handling | Understands `srcset`, `data-src`, `poster`, inline styles, CSS imports, meta images, and common JS asset strings. |
-| Controlled CDN mirroring | Downloads only the external domains you allow into `cdn/<domain>/...`. |
-| Ongoing archives | Uses `ETag` and `Last-Modified` metadata to skip unchanged resources with `--update`. |
-| Portable exports | Can produce zip archives and WARC response archives for sharing or long-term storage. |
+```console
+$ website-downloader --url https://example.com --destination example_backup --page-threads 4
 
-## Quick Start
+14:32:01 | INFO     | MainThread | [1/50] https://example.com/
+14:32:01 | INFO     | MainThread | [2/50] https://example.com/blog/
+14:32:02 | INFO     | MainThread | [3/50] https://example.com/about
+...
+14:32:09 | INFO     | MainThread | Crawl finished: 50 pages (0 cached), 214 assets (0 cached), 0 errors in 8.42s (0.17s/page)
+```
+
+Open `example_backup/index.html` in your browser — the whole site works from disk: pages, styles, scripts, images, fonts, and media, all with links rewritten for offline browsing.
+
+## ⚡ Quick Start
 
 ```bash
 git clone https://github.com/PKHarsimran/website-downloader.git
 cd website-downloader
 
 python -m venv .venv
-.venv\Scripts\activate
+.venv\Scripts\activate        # macOS/Linux: source .venv/bin/activate
 pip install -e .
 
 website-downloader --url https://example.com --destination example_backup --max-pages 100
 ```
 
-The compatibility script still works too:
+The classic script entry point still works too:
 
 ```bash
 python website-downloader.py --url https://example.com --destination example_backup
 ```
 
-On macOS or Linux, activate the virtual environment with:
+## 🤔 Why Not Just wget or HTTrack?
 
-```bash
-source .venv/bin/activate
-```
+Those tools are great — until you hit a modern website. This project exists for the gap between "one-liner that misses half the assets" and "write your own Scrapy project."
 
-## Install Options
+| | **website-downloader** | wget --mirror | HTTrack | Scrapy |
+| --- | :-: | :-: | :-: | :-: |
+| Modern assets: `srcset`, `data-src`, `poster`, CSS `@import`, JS asset strings | ✅ | partial | partial | build it yourself |
+| JavaScript rendering (React, Vue, Next.js) | ✅ Playwright | ❌ | ❌ | plugin |
+| Incremental re-mirroring (`ETag` / `Last-Modified`) | ✅ | timestamps only | ✅ | manual |
+| Cookies + custom headers for authorized portals | ✅ | ✅ | ✅ | ✅ |
+| Selective CDN mirroring with a domain allowlist | ✅ | ❌ | partial | manual |
+| Zip + WARC export | ✅ | WARC ✅ | ❌ | manual |
+| Windows-safe paths (long paths, reserved names, query hashing) | ✅ | ❌ | partial | manual |
+| Small, readable Python codebase you can extend | ✅ | ❌ (C) | ❌ (C) | framework |
 
-Start with the core install, then add extras only when you need them:
+## ✨ Highlights
 
-| Install | Use when you want |
-| --- | --- |
-| `pip install -e .` | Normal static-site crawling with `requests` and BeautifulSoup. |
-| `pip install -e ".[dev]"` | Tests, formatting, linting, and local contributor work. |
-| `pip install -e ".[fast]"` | Faster HTML parsing with lxml (used automatically when installed). |
-| `pip install -e ".[render]"` | Playwright-powered JavaScript rendering with `--render-js` or `--headless`. |
-| `pip install -e ".[ux]"` | Rich-powered terminal progress with `--progress`. |
+- 🚀 **Fast** — parallel page fetching (`--page-threads`, ~3–4× faster on multi-page sites), threaded asset downloads, and optional lxml parsing (`pip install -e ".[fast]"`).
+- 🔁 **Incremental** — `--update` skips unchanged pages and assets using `ETag`/`Last-Modified`, perfect for recurring archives.
+- ⚛️ **JavaScript-aware** — optional Playwright rendering for client-rendered sites (`--render-js`).
+- 🍪 **Authenticated** — reuse browser cookies and custom headers for portals, intranets, and staging sites you're allowed to access.
+- 🧭 **Sitemap seeding** — start from `sitemap.xml` (including nested sitemap indexes) for complete discovery.
+- 📦 **Portable output** — export mirrors as zip archives or WARC 1.1 response records.
+- 🤝 **Polite by default** — sequential pages unless you opt in, `--respect-robots`, `--delay`, retry with backoff, and per-asset size caps.
+- 🪟 **Cross-platform paths** — sanitizes Windows reserved names, shortens long paths, and hashes query strings to avoid collisions.
+- 🧪 **Tested** — pytest suite running against a real local HTTP fixture server, with CI and lint gates.
 
-## How It Works
+## 🛠 How It Works
 
 ```mermaid
 flowchart TD
@@ -101,10 +117,22 @@ In plain English:
 4. It finds links, images, scripts, stylesheets, fonts, media, and metadata assets.
 5. It follows same-site pages up to your `--max-pages` limit.
 6. It saves assets locally and rewrites references so pages still work offline.
-7. With `--update`, unchanged resources can be skipped using cache metadata.
-8. With `--zip-output` or `--warc-output`, the result can also be exported as an archive.
+7. With `--update`, unchanged resources are skipped using cache metadata.
+8. With `--zip-output` or `--warc-output`, the result is also exported as an archive.
 
-## Common Commands
+## 📦 Install Options
+
+Start with the core install, then add extras only when you need them:
+
+| Install | Use when you want |
+| --- | --- |
+| `pip install -e .` | Normal static-site crawling with `requests` and BeautifulSoup. |
+| `pip install -e ".[fast]"` | Faster HTML parsing with lxml (used automatically when installed). |
+| `pip install -e ".[render]"` | Playwright-powered JavaScript rendering with `--render-js` or `--headless`. |
+| `pip install -e ".[ux]"` | Rich-powered terminal progress with `--progress`. |
+| `pip install -e ".[dev]"` | Tests, formatting, linting, and local contributor work. |
+
+## 📖 Cookbook
 
 Mirror a small public site:
 
@@ -114,6 +142,17 @@ website-downloader ^
   --destination example_backup ^
   --max-pages 50
 ```
+
+Speed up a large mirror with parallel page fetching:
+
+```bash
+website-downloader ^
+  --url https://example.com ^
+  --max-pages 500 ^
+  --page-threads 4
+```
+
+`--page-threads` defaults to 1 so crawls stay polite; raise it only for sites that can handle concurrent requests. `--render-js` always uses a single page worker.
 
 Download selected CDN assets:
 
@@ -178,17 +217,6 @@ website-downloader ^
   --user-agent "WebsiteDownloader/0.2"
 ```
 
-Speed up a large mirror with parallel page fetching:
-
-```bash
-website-downloader ^
-  --url https://example.com ^
-  --max-pages 500 ^
-  --page-threads 4
-```
-
-`--page-threads` defaults to 1 so crawls stay polite; raise it only for sites that can handle concurrent requests. `--render-js` always uses a single page worker.
-
 Update an existing mirror without re-downloading unchanged resources:
 
 ```bash
@@ -208,7 +236,7 @@ website-downloader ^
   --warc-output example_backup.warc
 ```
 
-## JavaScript-Rendered Sites
+## ⚛️ JavaScript-Rendered Sites
 
 Some modern sites do not expose their real links and assets until JavaScript runs. For those, install the optional Playwright extra:
 
@@ -222,7 +250,7 @@ website-downloader --url https://example.com --render-js --max-pages 20
 
 `--render-js` and `--headless` are optional because Playwright is heavier than the default `requests` + BeautifulSoup path. Use them when a normal crawl only captures an empty app shell or misses important client-rendered links.
 
-## Live Progress
+## 📊 Live Progress
 
 Install the optional UX extra for a Rich-powered terminal dashboard:
 
@@ -233,21 +261,21 @@ website-downloader --url https://example.com --progress
 
 If `rich` is not installed, the crawler falls back to normal logging instead of failing.
 
-## Feature Flags At A Glance
+## 🎛 Feature Flags At A Glance
 
 | Flag | What it does | Best for |
 | --- | --- | --- |
+| `--page-threads` | Fetches HTML pages concurrently (default 1). | Faster mirroring of large sites that tolerate concurrent requests. |
 | `--render-js` / `--headless` | Uses Playwright before parsing the page. | React, Vue, Angular, Next.js, and other client-rendered sites. |
 | `--cookie-file` | Sends saved browser/session cookies. | Authorized portals, staging sites, docs behind login. |
 | `--header` | Adds custom request headers. | Bearer tokens, staging headers, API gateway headers. |
-| `--page-threads` | Fetches HTML pages concurrently (default 1). | Faster mirroring of large sites that tolerate concurrent requests. |
 | `--update` | Reuses cache metadata and skips unchanged resources when the server supports it. | Recurring mirrors and archives. |
 | `--sitemap` | Seeds the crawl from `sitemap.xml` or a supplied sitemap. | Faster, more complete discovery. |
 | `--progress` | Shows a Rich terminal progress dashboard when installed. | Long crawls where visibility matters. |
 | `--zip-output` | Exports the mirror folder as a zip. | Sharing, attaching, or storing snapshots. |
 | `--warc-output` | Writes a simple WARC response archive. | Archival workflows and future replay tooling. |
 
-## What Gets Rewritten
+## 🔁 What Gets Rewritten
 
 | Source | Rewritten for offline use |
 | --- | --- |
@@ -262,7 +290,7 @@ If `rich` is not installed, the crawler falls back to normal logging instead of 
 
 When external scripts or stylesheets are localized, the tool removes `integrity` and `crossorigin` where needed because those attributes often break offline copies.
 
-## Output Example
+## 📁 Output Example
 
 ```text
 example_backup/
@@ -283,27 +311,7 @@ example_backup/
 
 Open `index.html` in your browser to browse the mirrored copy.
 
-## Feature Snapshot
-
-- Same-origin recursive crawling.
-- Optional external asset downloading with domain allowlists.
-- Cookie-based authenticated crawling.
-- Custom request headers for bearer tokens and staging environments.
-- Optional JavaScript rendering with Playwright.
-- Sitemap-aware crawl seeding.
-- Incremental update mode using `ETag` and `Last-Modified`.
-- Optional Rich-powered progress dashboard.
-- Zip and WARC output formats.
-- Retry and backoff for unstable requests.
-- Worker-thread asset downloads.
-- Path sanitization for Windows/macOS/Linux.
-- Query-string hashing to avoid filename collisions.
-- Long-path fallback handling.
-- Local pytest suite and CI checks.
-
-## Local Development
-
-Install the development extra:
+## 🧑‍💻 Development
 
 ```bash
 pip install -e ".[dev]"
@@ -313,20 +321,15 @@ isort . --check-only
 ruff check .
 ```
 
-### PyCharm
+Using PyCharm? Open the repo folder, point it at a Python 3.10+ virtualenv, run `pip install -e ".[dev]"` in the terminal, and use the pytest runner on the `tests` folder.
 
-1. Open this repository folder in PyCharm.
-2. Create or select a Python 3.10+ virtual environment.
-3. In the PyCharm terminal, run `pip install -e ".[dev]"`.
-4. Run the `tests` folder with PyCharm's pytest runner.
-5. For manual CLI testing, create a Python run configuration for `website_downloader.cli` or run `python website-downloader.py --help`.
-
-## Project Structure
+<details>
+<summary><b>Project structure</b></summary>
 
 | Path | Purpose |
 | --- | --- |
 | `website_downloader/cli.py` | Argument parsing, validation, logging, and CLI entry point. |
-| `website_downloader/crawler.py` | Crawl coordination, asset queueing, workers, robots.txt support, and stats. |
+| `website_downloader/crawler.py` | Crawl coordination, page/asset worker pools, robots.txt support, and stats. |
 | `website_downloader/http.py` | Requests sessions, HTML fetches, binary downloads, and downloaded CSS/JS post-processing. |
 | `website_downloader/rewrite.py` | HTML, CSS, JavaScript, and `srcset` reference rewriting. |
 | `website_downloader/paths.py` | Filesystem-safe page, asset, and CDN path mapping. |
@@ -337,33 +340,31 @@ ruff check .
 | `website_downloader/exports.py` | Zip and WARC export helpers. |
 | `tests/` | Local pytest suite with a tiny fixture HTTP server. |
 
-## Roadmap Ideas
+</details>
 
-These are natural next steps for making the project more useful to developers:
+## 🗺 Roadmap
 
 - `--manifest crawl.json` with pages, assets, status codes, titles, headings, and errors.
 - Login-flow recording for complex SSO sites.
 - Stronger WARC metadata and replay compatibility.
 - Visual diff mode for migration and redesign checks.
 
-## Responsible Use
+Have an idea? [Open an issue](https://github.com/PKHarsimran/website-downloader/issues) — feature requests and bug reports are very welcome.
+
+## 🛡 Responsible Use
 
 Only mirror sites you own, have permission to archive, or are legally allowed to access. Authentication cookies can expose private content, so keep cookie files out of source control and avoid sharing generated mirrors that contain private data. Use `--respect-robots`, lower `--threads`, and `--delay` for polite crawling.
 
-## Licensing And Ownership
+## 🤝 Contributing
 
-This project is licensed under the MIT License. Others may use, copy, modify, and distribute the code if they keep the license notice. Your original code remains your copyrighted work, but the MIT license intentionally allows broad reuse.
+Contributions are welcome! Open an issue or pull request for bug reports, feature ideas, or improvements. The codebase is intentionally small and modular — most features live in a single focused module, so it's an easy project to hack on.
 
-If the project becomes a product, consider choosing a distinctive brand name and protecting that brand separately from the source code license.
+If this tool saved you time, consider **starring the repo** ⭐ — it helps others find it.
 
-## Support This Project
+## ☕ Support This Project
 
 [Donate via PayPal](https://www.paypal.com/donate/?business=PJVPSXG6V4CUG&no_recurring=1&item_name=Thank+you+for+the+coffee+%3A%29&currency_code=CAD)
 
-## Contributing
+## 📄 License
 
-Contributions are welcome. Please open an issue or pull request for bug reports, feature ideas, or improvements.
-
-## License
-
-This project is licensed under the MIT License.
+MIT — use it, fork it, ship it. See [LICENSE](LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pytest>=8.0",
     "ruff>=0.6",
 ]
+fast = ["lxml>=5.0"]
 render = ["playwright>=1.45"]
 ux = ["rich>=13.7"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,8 @@ class ConditionalHandler(QuietHandler):
     etag = '"test-etag"'
 
     def end_headers(self) -> None:
-        if self.path.endswith(".html") or self.path == "/":
-            self.send_header("ETag", self.etag)
-            self.send_header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+        self.send_header("ETag", self.etag)
+        self.send_header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
         super().end_headers()
 
     def do_GET(self) -> None:
@@ -122,7 +121,17 @@ def local_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
 def conditional_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
     site = tmp_path / "conditional-site"
     site.mkdir()
-    (site / "index.html").write_text("<html><body>Cached</body></html>", encoding="utf-8")
+    (site / "index.html").write_text(
+        """
+        <html>
+          <head><link rel="stylesheet" href="/style.css"></head>
+          <body>Cached <a href="/other">Other</a></body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    (site / "other").write_text("<html><body>Other page</body></html>", encoding="utf-8")
+    (site / "style.css").write_text("body { color: red; }", encoding="utf-8")
 
     with serve_directory_with_handler(site, ConditionalHandler) as base_url:
         yield base_url, site

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,12 @@ def test_validate_args_rejects_invalid_limits() -> None:
         validate_args(args)
 
 
+def test_validate_args_rejects_invalid_page_threads() -> None:
+    args = parse_args(["--url", "https://example.com", "--page-threads", "0"])
+    with pytest.raises(ValueError):
+        validate_args(args)
+
+
 def test_parse_header_accepts_authorization_header() -> None:
     assert parse_header("Authorization: Bearer token") == ("Authorization", "Bearer token")
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -111,3 +112,67 @@ def test_update_mode_uses_cache_metadata(conditional_site, tmp_path: Path) -> No
     assert first.pages_written == 1
     assert second.pages_cached == 1
     assert cache_file.exists()
+
+
+def test_update_recrawl_revisits_pages_from_cache_not_rewritten_links(
+    conditional_site, tmp_path: Path
+) -> None:
+    base_url, _site = conditional_site
+    output = tmp_path / "mirror"
+    cache_file = tmp_path / "cache.json"
+
+    def options() -> CrawlOptions:
+        return CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=5,
+            update=True,
+            cache_file=cache_file,
+        )
+
+    first = crawl_site(options())
+    assert first.pages_written == 2
+
+    second = crawl_site(options())
+    assert second.pages_cached == 2
+    assert second.pages_written == 0
+    assert second.assets_cached == 1
+
+
+def test_update_refetches_when_local_mirror_deleted(conditional_site, tmp_path: Path) -> None:
+    base_url, _site = conditional_site
+    output = tmp_path / "mirror"
+    cache_file = tmp_path / "cache.json"
+
+    def options() -> CrawlOptions:
+        return CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=5,
+            update=True,
+            cache_file=cache_file,
+        )
+
+    crawl_site(options())
+    shutil.rmtree(output)
+
+    second = crawl_site(options())
+    assert second.pages_written == 2
+    assert (output / "index.html").exists()
+    assert (output / "style.css").read_bytes() != b""
+
+
+def test_recrawl_without_update_treats_existing_assets_as_cached(
+    local_site, tmp_path: Path
+) -> None:
+    base_url, _site = local_site
+    output = tmp_path / "mirror"
+
+    def options() -> CrawlOptions:
+        return CrawlOptions(start_url=base_url, root=output, max_pages=2, threads=2)
+
+    crawl_site(options())
+    second = crawl_site(options())
+
+    assert second.assets_written == 0
+    assert second.assets_cached > 0

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -44,6 +44,31 @@ def test_crawl_site_mirrors_local_fixture(local_site, tmp_path: Path) -> None:
     assert "'/api/data'" in js
 
 
+def test_crawl_site_parallel_pages_mirrors_local_fixture(local_site, tmp_path: Path) -> None:
+    base_url, _site = local_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=2,
+            threads=2,
+            page_threads=4,
+        )
+    )
+
+    assert stats.pages_seen == 2
+    assert stats.pages_written == 2
+    assert (output / "index.html").exists()
+    assert (output / "about.html").exists()
+    assert (output / "assets" / "site.css").exists()
+    assert (output / "img" / "logo.png").exists()
+
+    html = (output / "index.html").read_text(encoding="utf-8")
+    assert 'href="assets/site.css"' in html
+
+
 def test_crawl_site_uses_sitemap_seed(local_site, tmp_path: Path) -> None:
     base_url, _site = local_site
     output = tmp_path / "mirror"

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -162,6 +162,22 @@ def test_update_refetches_when_local_mirror_deleted(conditional_site, tmp_path: 
     assert (output / "style.css").read_bytes() != b""
 
 
+def test_crawl_counts_fetch_failures_in_stats(local_site, tmp_path: Path) -> None:
+    base_url, _site = local_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=f"{base_url}missing-page.html",
+            root=output,
+            max_pages=1,
+        )
+    )
+
+    assert stats.errors == 1
+    assert stats.pages_written == 0
+
+
 def test_recrawl_without_update_treats_existing_assets_as_cached(
     local_site, tmp_path: Path
 ) -> None:

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -25,6 +25,22 @@ def test_rewrite_css_queues_nested_asset(tmp_path: Path) -> None:
     assert queued == [("https://example.com/img/bg.png", tmp_path / "img" / "bg.png")]
 
 
+def test_rewrite_css_import_url_form_maps_once(tmp_path: Path) -> None:
+    queued: list[str] = []
+    rewritten = rewrite_css_text(
+        "@import url('/assets/theme.css?v=2');",
+        "https://example.com/assets/site.css",
+        site_root=tmp_path,
+        root_netloc="example.com",
+        base_dir=tmp_path / "assets",
+        download_external_assets=False,
+        enqueue_asset=lambda url, path: queued.append(url),
+    )
+
+    assert queued == ["https://example.com/assets/theme.css?v=2"]
+    assert '@import "theme-q' in rewritten
+
+
 def test_rewrite_js_leaves_api_routes_alone(tmp_path: Path) -> None:
     rewritten = rewrite_js_text(
         "const img = '/static/logo.png'; const api = '/api/data';",

--- a/website_downloader/cli.py
+++ b/website_downloader/cli.py
@@ -65,6 +65,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-pages", type=int, default=50, help="Maximum HTML pages to crawl.")
     parser.add_argument("--threads", type=int, default=6, help="Concurrent asset download workers.")
     parser.add_argument(
+        "--page-threads",
+        type=int,
+        default=1,
+        help=(
+            "Concurrent HTML page fetch workers. The default of 1 crawls politely; "
+            "raise it to speed up large mirrors. --render-js always uses 1."
+        ),
+    )
+    parser.add_argument(
         "--download-external-assets",
         action="store_true",
         help="Download external CDN/static assets and rewrite allowed links locally.",
@@ -199,6 +208,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--max-pages must be >= 1")
     if args.threads < 1:
         raise ValueError("--threads must be >= 1")
+    if args.page_threads < 1:
+        raise ValueError("--page-threads must be >= 1")
     if args.delay < 0:
         raise ValueError("--delay must be >= 0")
     if args.max_asset_bytes is not None and args.max_asset_bytes < 1:
@@ -227,6 +238,7 @@ def main(argv: list[str] | None = None) -> int:
         root=make_root(args.url, args.destination),
         max_pages=args.max_pages,
         threads=args.threads,
+        page_threads=args.page_threads,
         download_external_assets=download_external_assets,
         external_domains=normalize_external_domains(args.external_domains),
         cookies=cookies,

--- a/website_downloader/constants.py
+++ b/website_downloader/constants.py
@@ -4,6 +4,10 @@ import re
 from importlib.util import find_spec
 
 HAS_BROTLI = find_spec("brotli") is not None or find_spec("brotlicffi") is not None
+HAS_LXML = find_spec("lxml") is not None
+
+# lxml parses markup much faster than the stdlib parser; use it when installed.
+HTML_PARSER = "lxml" if HAS_LXML else "html.parser"
 
 LOG_FMT = "%(asctime)s | %(levelname)-8s | %(threadName)s | %(message)s"
 

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -4,6 +4,8 @@ import logging
 import queue
 import threading
 import time
+from collections.abc import Callable
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
@@ -38,6 +40,7 @@ class CrawlOptions:
     root: Path
     max_pages: int = 50
     threads: int = 6
+    page_threads: int = 1
     download_external_assets: bool = False
     external_domains: set[str] | None = None
     cookies: dict[str, str] | None = None
@@ -79,6 +82,8 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
     asset_lock = threading.Lock()
     cache_lock = threading.Lock()
     record_lock = threading.Lock()
+    page_lock = threading.Lock()
+    stats_lock = threading.Lock()
     download_q: queue.Queue[tuple[str, Path] | None] = queue.Queue()
     saved_records: list[SavedResource] = []
 
@@ -89,6 +94,28 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
         cookies=options.cookies,
         headers=options.headers,
     )
+    thread_sessions = threading.local()
+    thread_sessions.session = page_session
+
+    def _session_for_thread():
+        session = getattr(thread_sessions, "session", None)
+        if session is None:
+            session = create_session(
+                user_agent=user_agent,
+                cookies=options.cookies,
+                headers=options.headers,
+            )
+            thread_sessions.session = session
+        return session
+
+    page_threads = max(1, options.page_threads)
+    if options.render_js and page_threads > 1:
+        log.info("JavaScript rendering is single-threaded; using one page worker.")
+        page_threads = 1
+    if options.delay and page_threads > 1:
+        log.warning(
+            "--delay applies per page worker; total request rate scales with --page-threads."
+        )
     robots = (
         _load_robots(start_url, page_session, options.timeout) if options.respect_robots else None
     )
@@ -98,9 +125,10 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
 
     def enqueue_page(url: str) -> None:
         normalized = canonicalize_url(url, start_url)
-        if normalized not in queued_pages and normalized not in seen_pages:
-            q_pages.put(normalized)
-            queued_pages.add(normalized)
+        with page_lock:
+            if normalized not in queued_pages and normalized not in seen_pages:
+                q_pages.put(normalized)
+                queued_pages.add(normalized)
 
     def enqueue_asset(url: str, dest: Path) -> None:
         abs_url = canonicalize_url(url)
@@ -163,92 +191,118 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                 records=saved_records,
                 record_lock=record_lock,
                 stats=stats,
+                stats_lock=stats_lock,
                 progress=progress,
             )
             if options.update:
                 for cached_url, entry in list(crawl_cache.entries.items()):
                     if entry.kind == "asset":
                         enqueue_asset(cached_url, Path(entry.path))
-            while not q_pages.empty() and len(seen_pages) < options.max_pages:
-                page_url = canonicalize_url(q_pages.get())
-                if page_url in seen_pages:
-                    continue
-                if robots is not None and not robots.can_fetch(user_agent, page_url):
-                    log.info("Blocked by robots.txt: %s", page_url)
-                    continue
 
-                seen_pages.add(page_url)
-                stats.pages_seen = len(seen_pages)
-                log.info("[%s/%s] %s", len(seen_pages), options.max_pages, page_url)
-                progress.page_seen(len(seen_pages), options.max_pages, page_url)
+            def claim_page(page_url: str) -> bool:
+                with page_lock:
+                    if page_url in seen_pages:
+                        return False
+                    if robots is not None and not robots.can_fetch(user_agent, page_url):
+                        log.info("Blocked by robots.txt: %s", page_url)
+                        return False
+                    seen_pages.add(page_url)
+                    claimed = len(seen_pages)
+                stats.pages_seen = claimed
+                log.info("[%s/%s] %s", claimed, options.max_pages, page_url)
+                progress.page_seen(claimed, options.max_pages, page_url)
+                return True
 
-                local_path = to_local_path(urlparse(page_url), options.root)
-                soup = fetch_html(
-                    page_url,
-                    session=page_session,
-                    timeout=options.timeout,
-                    renderer=renderer,
-                    conditional_headers=(
-                        crawl_cache.conditional_headers(page_url) if options.update else None
-                    ),
-                    cached_path=local_path,
-                )
-                if soup is None or soup.soup is None:
-                    stats.errors += 1
-                    progress.error()
-                    continue
-
-                if soup.not_modified:
-                    # The saved copy has links rewritten to local paths, so
-                    # discovering references from it would queue bogus URLs.
-                    stats.pages_cached += 1
-                    progress.page_saved(cached=True)
-                else:
-                    _discover_references(
-                        soup.soup,
-                        page_url=page_url,
-                        root=options.root,
-                        root_netloc=root_netloc,
-                        q_pages=q_pages,
-                        queued_pages=queued_pages,
-                        seen_pages=seen_pages,
-                        enqueue_asset=enqueue_asset,
-                        options=options,
-                    )
-                    create_dir(local_path.parent)
-                    rewrite_links(
-                        soup.soup,
+            def process_page(page_url: str) -> None:
+                try:
+                    local_path = to_local_path(urlparse(page_url), options.root)
+                    result = fetch_html(
                         page_url,
-                        options.root,
-                        local_path.parent,
-                        options.download_external_assets,
-                        options.external_domains,
+                        session=_session_for_thread(),
+                        timeout=options.timeout,
+                        renderer=renderer,
+                        conditional_headers=(
+                            crawl_cache.conditional_headers(page_url) if options.update else None
+                        ),
+                        cached_path=local_path,
                     )
-                    safe_write_text(local_path, str(soup.soup), encoding="utf-8")
-                    stats.pages_written += 1
-                    progress.page_saved()
-                    if options.update:
-                        with cache_lock:
-                            crawl_cache.update(
-                                url=page_url,
-                                path=local_path,
-                                kind="page",
-                                status_code=soup.status_code,
-                                response_headers=soup.headers,
-                            )
-                    with record_lock:
-                        saved_records.append(
-                            SavedResource(
-                                url=page_url,
-                                path=local_path,
-                                kind="page",
-                                status_code=soup.status_code,
-                                content_type=soup.content_type or "text/html",
-                            )
-                        )
+                    if result is None or result.soup is None:
+                        with stats_lock:
+                            stats.errors += 1
+                        progress.error()
+                        return
 
+                    if result.not_modified:
+                        # The saved copy has links rewritten to local paths, so
+                        # discovering references from it would queue bogus URLs.
+                        with stats_lock:
+                            stats.pages_cached += 1
+                        progress.page_saved(cached=True)
+                    else:
+                        _discover_references(
+                            result.soup,
+                            page_url=page_url,
+                            root=options.root,
+                            root_netloc=root_netloc,
+                            enqueue_page=enqueue_page,
+                            enqueue_asset=enqueue_asset,
+                            options=options,
+                        )
+                        create_dir(local_path.parent)
+                        rewrite_links(
+                            result.soup,
+                            page_url,
+                            options.root,
+                            local_path.parent,
+                            options.download_external_assets,
+                            options.external_domains,
+                        )
+                        safe_write_text(local_path, str(result.soup), encoding="utf-8")
+                        with stats_lock:
+                            stats.pages_written += 1
+                        progress.page_saved()
+                        if options.update:
+                            with cache_lock:
+                                crawl_cache.update(
+                                    url=page_url,
+                                    path=local_path,
+                                    kind="page",
+                                    status_code=result.status_code,
+                                    response_headers=result.headers,
+                                )
+                        with record_lock:
+                            saved_records.append(
+                                SavedResource(
+                                    url=page_url,
+                                    path=local_path,
+                                    kind="page",
+                                    status_code=result.status_code,
+                                    content_type=result.content_type or "text/html",
+                                )
+                            )
+                except Exception:
+                    log.exception("Failed to process page %s", page_url)
+                    with stats_lock:
+                        stats.errors += 1
+                    progress.error()
                 if options.delay:
                     time.sleep(options.delay)
+
+            if page_threads == 1:
+                # Inline path keeps Playwright rendering on this thread.
+                while not q_pages.empty() and len(seen_pages) < options.max_pages:
+                    page_url = q_pages.get()
+                    if claim_page(page_url):
+                        process_page(page_url)
+            else:
+                _run_page_pool(
+                    page_threads=page_threads,
+                    q_pages=q_pages,
+                    claim_page=claim_page,
+                    process_page=process_page,
+                    max_pages=options.max_pages,
+                    seen_pages=seen_pages,
+                )
     finally:
         download_q.join()
         for _ in workers:
@@ -285,6 +339,36 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
     return stats
 
 
+def _run_page_pool(
+    *,
+    page_threads: int,
+    q_pages: queue.Queue[str],
+    claim_page: Callable[[str], bool],
+    process_page: Callable[[str], None],
+    max_pages: int,
+    seen_pages: set[str],
+) -> None:
+    """Fetch pages concurrently while honoring the max_pages budget.
+
+    Pages are claimed (marked seen) before submission, so the budget can
+    never be exceeded. The crawl is done when the queue is empty and no
+    page is in flight; in-flight pages may still enqueue new ones.
+    """
+    with ThreadPoolExecutor(max_workers=page_threads, thread_name_prefix="Page") as pool:
+        pending: set[Future] = set()
+        while True:
+            while len(seen_pages) < max_pages and len(pending) < page_threads:
+                try:
+                    page_url = q_pages.get_nowait()
+                except queue.Empty:
+                    break
+                if claim_page(page_url):
+                    pending.add(pool.submit(process_page, page_url))
+            if not pending:
+                break
+            _done, pending = wait(pending, return_when=FIRST_COMPLETED)
+
+
 class _optional_renderer:
     def __init__(self, renderer):
         self.renderer = renderer
@@ -313,6 +397,7 @@ def _start_workers(
     records: list[SavedResource],
     record_lock: threading.Lock,
     stats: CrawlStats,
+    stats_lock: threading.Lock,
     progress,
 ) -> list[threading.Thread]:
     def worker() -> None:
@@ -342,15 +427,17 @@ def _start_workers(
                     conditional_headers=cache.conditional_headers(url) if options.update else None,
                 )
                 if result is None:
-                    with record_lock:
+                    with stats_lock:
                         stats.errors += 1
                     progress.error()
                     continue
                 if result.not_modified:
-                    stats.assets_cached += 1
+                    with stats_lock:
+                        stats.assets_cached += 1
                     progress.asset_saved(cached=True)
                     continue
-                stats.assets_written += 1
+                with stats_lock:
+                    stats.assets_written += 1
                 progress.asset_saved()
                 if options.update:
                     with cache_lock:
@@ -404,9 +491,7 @@ def _discover_references(
     page_url: str,
     root: Path,
     root_netloc: str,
-    q_pages: queue.Queue[str],
-    queued_pages: set[str],
-    seen_pages: set[str],
+    enqueue_page,
     enqueue_asset,
     options: CrawlOptions,
 ) -> None:
@@ -423,9 +508,7 @@ def _discover_references(
                 page_url=page_url,
                 root=root,
                 root_netloc=root_netloc,
-                q_pages=q_pages,
-                queued_pages=queued_pages,
-                seen_pages=seen_pages,
+                enqueue_page=enqueue_page,
                 enqueue_asset=enqueue_asset,
                 options=options,
             )
@@ -483,9 +566,7 @@ def _discover_attr(
     page_url: str,
     root: Path,
     root_netloc: str,
-    q_pages: queue.Queue[str],
-    queued_pages: set[str],
-    seen_pages: set[str],
+    enqueue_page,
     enqueue_asset,
     options: CrawlOptions,
 ) -> None:
@@ -505,9 +586,7 @@ def _discover_attr(
     )
 
     if is_page:
-        if abs_url not in seen_pages and abs_url not in queued_pages:
-            q_pages.put(abs_url)
-            queued_pages.add(abs_url)
+        enqueue_page(abs_url)
         return
 
     _enqueue_asset_candidate(

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -116,6 +116,12 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
         download_q.put((abs_url, dest))
 
     enqueue_page(start_url)
+    if options.update:
+        # Saved pages contain rewritten local links, so a 304 page cannot be
+        # re-discovered from its own HTML. Seed known pages from the cache.
+        for cached_url, entry in crawl_cache.entries.items():
+            if entry.kind == "page":
+                enqueue_page(cached_url)
     if options.sitemap:
         for sitemap_url in load_sitemap_urls(
             options.sitemap,
@@ -161,6 +167,10 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                 stats=stats,
                 progress=progress,
             )
+            if options.update:
+                for cached_url, entry in list(crawl_cache.entries.items()):
+                    if entry.kind == "asset":
+                        enqueue_asset(cached_url, Path(entry.path))
             while not q_pages.empty() and len(seen_pages) < options.max_pages:
                 page_url = canonicalize_url(q_pages.get())
                 if page_url in seen_pages:
@@ -189,22 +199,23 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                     progress.error()
                     continue
 
-                _discover_references(
-                    soup.soup,
-                    page_url=page_url,
-                    root=options.root,
-                    root_netloc=root_netloc,
-                    q_pages=q_pages,
-                    queued_pages=queued_pages,
-                    seen_pages=seen_pages,
-                    enqueue_asset=enqueue_asset,
-                    options=options,
-                )
-
                 if soup.not_modified:
+                    # The saved copy has links rewritten to local paths, so
+                    # discovering references from it would queue bogus URLs.
                     stats.pages_cached += 1
                     progress.page_saved(cached=True)
                 else:
+                    _discover_references(
+                        soup.soup,
+                        page_url=page_url,
+                        root=options.root,
+                        root_netloc=root_netloc,
+                        q_pages=q_pages,
+                        queued_pages=queued_pages,
+                        seen_pages=seen_pages,
+                        enqueue_asset=enqueue_asset,
+                        options=options,
+                    )
                     create_dir(local_path.parent)
                     rewrite_links(
                         soup.soup,

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -25,8 +25,6 @@ from .urltools import (
     is_httpish,
     is_internal,
     is_non_fetchable,
-    normalize_url,
-    protocol_fix,
 )
 
 log = logging.getLogger(__name__)
@@ -69,6 +67,7 @@ class CrawlStats:
     assets_cached: int = 0
     pages_written: int = 0
     assets_written: int = 0
+    errors: int = 0
 
 
 def crawl_site(options: CrawlOptions) -> CrawlStats:
@@ -98,20 +97,19 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
     stats = CrawlStats(pages_seen=0, assets_queued=0, elapsed_seconds=0.0)
 
     def enqueue_page(url: str) -> None:
-        normalized = normalize_url(canonicalize_url(url, start_url))
+        normalized = canonicalize_url(url, start_url)
         if normalized not in queued_pages and normalized not in seen_pages:
             q_pages.put(normalized)
             queued_pages.add(normalized)
 
     def enqueue_asset(url: str, dest: Path) -> None:
-        abs_url = normalize_url(canonicalize_url(url))
+        abs_url = canonicalize_url(url)
         with asset_lock:
             if abs_url in queued_assets:
                 return
             queued_assets.add(abs_url)
             stats.assets_queued = len(queued_assets)
         progress_reporter.asset_queued()
-        create_dir(dest.parent)
         log.debug("Queue asset: %s -> %s", abs_url, dest)
         download_q.put((abs_url, dest))
 
@@ -196,6 +194,7 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                     cached_path=local_path,
                 )
                 if soup is None or soup.soup is None:
+                    stats.errors += 1
                     progress.error()
                     continue
 
@@ -262,8 +261,12 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
     stats.elapsed_seconds = elapsed
     if seen_pages:
         log.info(
-            "Crawl finished: %s pages in %.2fs (%.2fs avg)",
+            "Crawl finished: %s pages (%s cached), %s assets (%s cached), %s errors in %.2fs (%.2fs/page)",
             len(seen_pages),
+            stats.pages_cached,
+            stats.assets_written,
+            stats.assets_cached,
+            stats.errors,
             elapsed,
             elapsed / len(seen_pages),
         )
@@ -339,6 +342,8 @@ def _start_workers(
                     conditional_headers=cache.conditional_headers(url) if options.update else None,
                 )
                 if result is None:
+                    with record_lock:
+                        stats.errors += 1
                     progress.error()
                     continue
                 if result.not_modified:
@@ -488,7 +493,7 @@ def _discover_attr(
     if _skip_candidate(link_raw):
         return
 
-    abs_url = normalize_url(canonicalize_url(protocol_fix(link_raw, page_url), page_url))
+    abs_url = canonicalize_url(link_raw, page_url)
     parsed = urlparse(abs_url)
     is_ext = not is_internal(abs_url, root_netloc)
     suffix = Path(parsed.path).suffix.lower()
@@ -552,11 +557,7 @@ def _enqueue_asset_candidate(
 ) -> None:
     if _skip_candidate(candidate):
         return
-    abs_url = normalize_url(
-        candidate
-        if already_absolute
-        else canonicalize_url(protocol_fix(candidate, page_url), page_url)
-    )
+    abs_url = candidate if already_absolute else canonicalize_url(candidate, page_url)
     parsed = urlparse(abs_url)
     if _skip_candidate(abs_url):
         return

--- a/website_downloader/http.py
+++ b/website_downloader/http.py
@@ -84,13 +84,17 @@ def fetch_html(
         headers = dict(response.headers)
         if response.status_code == 304:
             soup = _read_cached_html(cached_path)
-            return HtmlFetchResult(
-                soup=soup,
-                status_code=304,
-                headers=headers,
-                not_modified=True,
-                content_type=response.headers.get("Content-Type"),
-            )
+            if soup is not None:
+                return HtmlFetchResult(
+                    soup=soup,
+                    status_code=304,
+                    headers=headers,
+                    not_modified=True,
+                    content_type=response.headers.get("Content-Type"),
+                )
+            log.info("Server sent 304 but local copy is missing; refetching %s", url)
+            response = session.get(url, timeout=timeout)
+            headers = dict(response.headers)
         response.raise_for_status()
         return HtmlFetchResult(
             soup=BeautifulSoup(response.text, "html.parser"),
@@ -129,19 +133,31 @@ def fetch_binary(
         log.debug("Skipping non-fetchable URL: %s", url)
         return None
     if dest.exists() and not update:
-        return None
+        # Already mirrored in a previous run; report it as cached.
+        return BinaryFetchResult(
+            path=dest,
+            status_code=200,
+            headers={},
+            not_modified=True,
+        )
 
     try:
         response = session.get(url, timeout=timeout, stream=True, headers=conditional_headers)
         headers = dict(response.headers)
-        if response.status_code == 304 and dest.exists():
-            return BinaryFetchResult(
-                path=dest,
-                status_code=304,
-                headers=headers,
-                not_modified=True,
-                content_type=response.headers.get("Content-Type"),
-            )
+        if response.status_code == 304:
+            if dest.exists():
+                return BinaryFetchResult(
+                    path=dest,
+                    status_code=304,
+                    headers=headers,
+                    not_modified=True,
+                    content_type=response.headers.get("Content-Type"),
+                )
+            # A 304 has no body; without the local file we must refetch,
+            # otherwise we would write an empty asset.
+            log.info("Server sent 304 but local copy is missing; refetching %s", url)
+            response = session.get(url, timeout=timeout, stream=True)
+            headers = dict(response.headers)
         response.raise_for_status()
         if _too_large(response, max_asset_bytes):
             log.warning("Skipping asset over size limit: %s", url)

--- a/website_downloader/http.py
+++ b/website_downloader/http.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-from .constants import CHUNK_SIZE, DEFAULT_HEADERS, TIMEOUT
+from .constants import CHUNK_SIZE, DEFAULT_HEADERS, HTML_PARSER, TIMEOUT
 from .paths import create_dir, shorten_segment
 from .rewrite import EnqueueAsset, rewrite_css_text, rewrite_js_text
 from .urltools import is_allowed_external, is_httpish, is_internal, is_non_fetchable
@@ -75,7 +75,7 @@ def fetch_html(
         if renderer is not None:
             html = renderer.fetch(url)
             return HtmlFetchResult(
-                soup=BeautifulSoup(html, "html.parser"),
+                soup=BeautifulSoup(html, HTML_PARSER),
                 status_code=200,
                 headers={},
                 content_type="text/html",
@@ -96,8 +96,10 @@ def fetch_html(
             response = session.get(url, timeout=timeout)
             headers = dict(response.headers)
         response.raise_for_status()
+        # Parse from bytes so BeautifulSoup can honor <meta charset> and BOMs;
+        # response.text falls back to ISO-8859-1 when no charset header is sent.
         return HtmlFetchResult(
-            soup=BeautifulSoup(response.text, "html.parser"),
+            soup=BeautifulSoup(response.content, HTML_PARSER),
             status_code=response.status_code,
             headers=headers,
             content_type=response.headers.get("Content-Type"),
@@ -202,7 +204,7 @@ def fetch_binary(
 def _read_cached_html(cached_path: Path | None) -> BeautifulSoup | None:
     if cached_path is None or not cached_path.exists():
         return None
-    return BeautifulSoup(cached_path.read_text(encoding="utf-8", errors="ignore"), "html.parser")
+    return BeautifulSoup(cached_path.read_text(encoding="utf-8", errors="ignore"), HTML_PARSER)
 
 
 def _too_large(response: requests.Response, max_asset_bytes: int | None) -> bool:

--- a/website_downloader/progress.py
+++ b/website_downloader/progress.py
@@ -56,7 +56,7 @@ class RichProgressReporter(ProgressReporter):
         )
         self.assets_queued = 0
         self.assets_saved = 0
-        self.pages_cached = 0
+        self.cached_total = 0
 
     def __enter__(self) -> RichProgressReporter:
         self.progress.__enter__()
@@ -80,7 +80,7 @@ class RichProgressReporter(ProgressReporter):
 
     def page_saved(self, cached: bool = False) -> None:
         if cached:
-            self.pages_cached += 1
+            self.cached_total += 1
             self._refresh_fields()
         self.progress.advance(self.task_id)
 
@@ -91,7 +91,7 @@ class RichProgressReporter(ProgressReporter):
     def asset_saved(self, cached: bool = False) -> None:
         self.assets_saved += 1
         if cached:
-            self.pages_cached += 1
+            self.cached_total += 1
         self._refresh_fields()
 
     def _refresh_fields(self) -> None:
@@ -99,7 +99,7 @@ class RichProgressReporter(ProgressReporter):
             self.task_id,
             assets_queued=self.assets_queued,
             assets_saved=self.assets_saved,
-            cached=self.pages_cached,
+            cached=self.cached_total,
         )
 
 

--- a/website_downloader/rewrite.py
+++ b/website_downloader/rewrite.py
@@ -132,7 +132,9 @@ def rewrite_css_text(
             return match.group(0)
         return f'@import "{mapped}";'
 
-    return CSS_IMPORT_RE.sub(repl_import, CSS_URL_RE.sub(repl_url, css_text))
+    # Imports first: running the url() pass first would leave the import
+    # pass re-mapping already-rewritten local paths as if they were URLs.
+    return CSS_URL_RE.sub(repl_url, CSS_IMPORT_RE.sub(repl_import, css_text))
 
 
 def rewrite_js_text(


### PR DESCRIPTION
## What changed

Four commits: crawler bug fixes with regression tests, performance work, a new parallel page fetching feature, and a README restructure.

### Bug fixes (`9e98fb5`)

- **`--update` re-crawls queued bogus URLs**: 304 pages were re-parsed from the saved local file, whose links are already rewritten to local paths (`other.html`, `cdn/...`), producing 404s that burned the `--max-pages` budget. Update runs now skip discovery on cached pages and re-seed known pages/assets from the update cache instead.
- **304 with a missing local copy** wrote a 0-byte asset (a 304 has no body) or silently skipped the page; both now refetch without conditional headers.
- **Assets already on disk counted as errors** when re-running into the same folder; they now report as cached.
- **CSS `@import url(...)` was rewritten twice**, enqueueing a garbage download URL; the import pass now runs before the `url()` pass.

### Performance and internals (`7ded192`)

- Auto-detect lxml for HTML parsing with a new `.[fast]` extra (falls back to `html.parser`).
- Parse pages from raw bytes so BeautifulSoup honors `<meta charset>`/BOMs instead of requests defaulting to ISO-8859-1.
- Removed redundant URL re-parsing in the discovery hot path; stopped pre-creating directories for queued assets.
- `CrawlStats` gained an `errors` counter and the end-of-crawl summary reports pages/assets/cache hits/errors.

### Parallel page fetching (`2d584d5`)

- New `--page-threads` option (default 1 keeps the previous polite sequential behavior). Pages are claimed against the `--max-pages` budget under a lock before submission, so the budget can never be exceeded; the crawl ends when the queue is empty and nothing is in flight.
- Benchmark: 12 pages at 100 ms simulated latency: 1.79 s sequential vs 0.48 s with 4 workers, identical output.
- `--render-js` clamps to one worker (Playwright sync API is single-threaded); `--delay` warns that it applies per worker; page workers use thread-local sessions; stats counters now update under a lock (asset workers previously incremented them unguarded).

### README (`592d433`)

- Centered header with tagline and terminal demo, comparison table vs wget/HTTrack/Scrapy, highlights list, cookbook layout, collapsible project-structure table, and star/issue calls to action. All technical content preserved.

## Why

The update-mode bugs made recurring mirrors (`--update`) actively harmful — each re-run wasted budget on 404s and could corrupt assets. The rest makes large mirrors meaningfully faster and the project easier to discover.

## Reviewer notes

- Test suite grew from 23 to 30 tests; every bug fix has a regression test that failed before the fix. The conditional-site fixture now serves an extensionless page and a stylesheet with ETags to exercise the update paths.
- `tests/test_crawler.py::test_crawl_site_parallel_pages_mirrors_local_fixture` verifies parallel output matches sequential.
- All tests pass with and without lxml installed (both parser paths).
- CHANGELOG has a new Unreleased section covering everything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
