### PR TITLE
Prepare v2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v2.6.0 - 2026-07-06
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "website-downloader"
-version = "2.5.0"
+version = "2.6.0"
 description = "A Python CLI for mirroring websites into browsable offline copies."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/website_downloader/__init__.py
+++ b/website_downloader/__init__.py
@@ -1,3 +1,3 @@
 """Website Downloader package."""
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"


### PR DESCRIPTION
Version bump to 2.6.0 in `pyproject.toml` and `website_downloader/__init__.py`, and the changelog Unreleased section is now dated `v2.6.0 - 2026-07-06`.

Follow-up to #45. Once this merges, the `v2.6.0` tag and GitHub release will be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)