### PR TITLE
Add PyPI publish workflow (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Run tests against the built wheel
+        run: |
+          pip install dist/*.whl
+          pip install pytest
+          pytest
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/website-downloader
+    permissions:
+      # Required for PyPI Trusted Publishing (OIDC) - no API token needed.
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What changed

Adds `.github/workflows/publish.yml`: builds the sdist and wheel, runs the test suite **against the built wheel**, and publishes to PyPI.

## Triggers

- Automatically when a GitHub release is **published**
- Manually via **workflow_dispatch** (useful to publish the existing v2.6.0 without cutting a new release)

## Security

Uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) instead of an API token secret. The publish job runs in a `pypi` GitHub environment with `id-token: write` and nothing else.

## Setup required before merging (one-time, ~2 minutes)

1. Create/log in to your account on [pypi.org](https://pypi.org).
2. Go to **Account settings -> Publishing -> Add a new pending publisher** and enter:
   - PyPI project name: `website-downloader` (if taken, pick e.g. `website-downloader-cli` and update `name` in `pyproject.toml` on this branch first)
   - Owner: `PKHarsimran`
   - Repository: `website-downloader`
   - Workflow name: `publish.yml`
   - Environment: `pypi`
3. Merge this PR, then run the workflow manually from the Actions tab (workflow_dispatch) to publish v2.6.0.

Verified locally: `python -m build` produces `website_downloader-2.6.0.tar.gz` and `website_downloader-2.6.0-py3-none-any.whl` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)