### PR TITLE
Fix extensionless attachment images treated as HTML (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Images and media referenced from extensionless URLs (e.g. OpenProject attachment `.../attachments/228/content` endpoints) are now downloaded as binary assets. Previously such references were skipped during discovery while still being rewritten to a local path, leaving a broken link — and older versions mis-classified them as HTML pages and corrupted the file during text decoding. ([#49](https://github.com/PKHarsimran/website-downloader/issues/49))
+
 ## v2.6.0 - 2026-07-06
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,32 @@ def local_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
         yield base_url, site
 
 
+PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000a49444154789c6300010000050001"
+)
+
+
+@pytest.fixture
+def attachment_site(tmp_path: Path) -> Iterator[tuple[str, Path, bytes]]:
+    """Site with an image served from an extensionless attachment URL."""
+    site = tmp_path / "attachment-site"
+    (site / "attachments" / "228").mkdir(parents=True)
+    (site / "index.html").write_text(
+        """
+        <html><body>
+          <img class="op-uc-image" src="/attachments/228/content">
+        </body></html>
+        """,
+        encoding="utf-8",
+    )
+    # No file extension; served as application/octet-stream binary data.
+    (site / "attachments" / "228" / "content").write_bytes(PNG_BYTES)
+
+    with serve_directory(site) as base_url:
+        yield base_url, site, PNG_BYTES
+
+
 @pytest.fixture
 def conditional_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
     site = tmp_path / "conditional-site"

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -69,9 +69,7 @@ def test_crawl_site_parallel_pages_mirrors_local_fixture(local_site, tmp_path: P
     assert 'href="assets/site.css"' in html
 
 
-def test_crawl_downloads_extensionless_attachment_image(
-    attachment_site, tmp_path: Path
-) -> None:
+def test_crawl_downloads_extensionless_attachment_image(attachment_site, tmp_path: Path) -> None:
     base_url, _site, png_bytes = attachment_site
     output = tmp_path / "mirror"
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -69,6 +69,25 @@ def test_crawl_site_parallel_pages_mirrors_local_fixture(local_site, tmp_path: P
     assert 'href="assets/site.css"' in html
 
 
+def test_crawl_downloads_extensionless_attachment_image(
+    attachment_site, tmp_path: Path
+) -> None:
+    base_url, _site, png_bytes = attachment_site
+    output = tmp_path / "mirror"
+
+    crawl_site(CrawlOptions(start_url=base_url, root=output, max_pages=1))
+
+    saved = output / "attachments" / "228" / "content"
+    assert saved.exists(), "extensionless attachment image should be downloaded"
+    assert saved.read_bytes() == png_bytes, "image bytes must be saved unchanged"
+
+    # The <img> must point at the local file, and it must NOT be turned into a
+    # crawled .html page.
+    html = (output / "index.html").read_text(encoding="utf-8")
+    assert "attachments/228/content" in html
+    assert not (output / "attachments" / "228" / "content.html").exists()
+
+
 def test_crawl_site_uses_sitemap_seed(local_site, tmp_path: Path) -> None:
     base_url, _site = local_site
     output = tmp_path / "mirror"

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -55,6 +55,27 @@ def test_rewrite_js_leaves_api_routes_alone(tmp_path: Path) -> None:
     assert "'/api/data'" in rewritten
 
 
+def test_rewrite_srcset_rewrites_extensionless_attachment(tmp_path: Path) -> None:
+    soup = BeautifulSoup(
+        '<img src="/attachments/228/content" '
+        'srcset="/attachments/228/content 1x, /attachments/229/content 2x">',
+        "html.parser",
+    )
+    rewrite_links(
+        soup,
+        "https://example.com/page/index.html",
+        tmp_path,
+        tmp_path / "page",
+        download_external_assets=False,
+    )
+
+    img = soup.find("img")
+    # Both the src and every srcset candidate must point at the local copy so
+    # offline mirrors and zip exports keep the responsive image working.
+    assert img["src"] == "../attachments/228/content"
+    assert img["srcset"] == "../attachments/228/content 1x, ../attachments/229/content 2x"
+
+
 def test_rewrite_links_skips_canonical_and_rewrites_assets(tmp_path: Path) -> None:
     soup = BeautifulSoup(
         """

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -33,6 +33,12 @@ log = logging.getLogger(__name__)
 
 PAGE_SUFFIXES = {"", ".html", ".htm"}
 
+# Tags whose asset references are downloaded even when the URL has no file
+# extension. Media served from extensionless endpoints (e.g. OpenProject
+# attachment ".../attachments/228/content" URLs) must be fetched as binary,
+# not skipped or mistaken for an HTML page.
+EXTENSIONLESS_ASSET_TAGS = {"script", "link", "img", "source", "video", "audio", "embed", "track"}
+
 
 @dataclass
 class CrawlOptions:
@@ -533,6 +539,7 @@ def _discover_references(
                         root_netloc=root_netloc,
                         enqueue_asset=enqueue_asset,
                         options=options,
+                        tag_name=tag.name,
                     )
 
         if tag.has_attr("style"):
@@ -648,7 +655,7 @@ def _enqueue_asset_candidate(
         if not is_allowed_external(abs_url, options.external_domains):
             log.debug("Blocked external asset outside whitelist: %s", abs_url)
             return
-        if tag_name not in {"script", "link"} and not parsed.path.lower().endswith(
+        if tag_name not in EXTENSIONLESS_ASSET_TAGS and not parsed.path.lower().endswith(
             ASSET_EXTENSIONS
         ):
             return
@@ -659,7 +666,7 @@ def _enqueue_asset_candidate(
     if (
         parsed.path
         and not parsed.path.lower().endswith(ASSET_EXTENSIONS)
-        and tag_name not in {"script", "link"}
+        and tag_name not in EXTENSIONLESS_ASSET_TAGS
     ):
         return
 

--- a/website_downloader/rewrite.py
+++ b/website_downloader/rewrite.py
@@ -52,6 +52,7 @@ def _map_asset_url(
     download_external_assets: bool,
     external_domains: set[str] | None = None,
     enqueue_asset: EnqueueAsset | None = None,
+    require_extension: bool = True,
 ) -> str | None:
     if _skippable_url(url_part):
         return None
@@ -62,7 +63,11 @@ def _map_asset_url(
 
     abs_url = canonicalize_url(fixed_url, base_url)
     parsed = urlparse(abs_url)
-    if not parsed.path.lower().endswith(ASSET_EXTENSIONS):
+    # CSS/JS/meta callers require a known extension to avoid rewriting things
+    # that merely look like paths (e.g. API strings). Media callers such as
+    # srcset pass require_extension=False so extensionless attachment URLs are
+    # rewritten to match what the crawler downloads.
+    if require_extension and not parsed.path.lower().endswith(ASSET_EXTENSIONS):
         return None
 
     is_ext = not is_internal(abs_url, root_netloc)
@@ -322,6 +327,7 @@ def _rewrite_srcset(
             base_dir=page_dir,
             download_external_assets=download_external_assets,
             external_domains=external_domains,
+            require_extension=False,
         )
         if mapped is not None:
             parts[0] = mapped


### PR DESCRIPTION
## Fixes #49

Images/media served from **extensionless URLs** (like OpenProject attachment `.../attachments/228/content` endpoints) were mishandled.

## Root cause

The asset-discovery gate in `crawler.py` only allowed extensionless URLs through for `<script>` and `<link>` tags. An `<img src=".../content">` was therefore **skipped** during discovery — yet `rewrite_links` still rewrote its `src` to a local path (the direct-attribute rewrite has no extension gate), leaving the mirror pointing at a file that was never downloaded (broken image). In older standalone versions the same extensionless URL was queued as an **HTML page** and text-decoded, corrupting the binary — the "REPLACEMENT CHARACTER" behavior in the report.

## Fix

- Media-bearing tags (`img`, `source`, `video`, `audio`, `embed`, `track`) now download even without a recognized file extension, matching how the rewrite side already treats their `src`/`href`. Files stream as raw bytes, so the image format is preserved.
- `srcset` entries carry their tag name through discovery for the same handling.
- `<a href>` still becomes a crawled page; `<script>`/`<link>` behavior is unchanged.

## Test

New regression test with a fixture serving a PNG from an extensionless attachment URL. It asserts the bytes are saved unchanged and the URL is **not** turned into a `.html` page. Verified it fails on the old gate and passes with the fix; full suite (31 tests) green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)