### PR TITLE
Prepare v2.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Unreleased
+## v2.6.1 - 2026-07-08
 
 ### Fixed
 
-- Images and media referenced from extensionless URLs (e.g. OpenProject attachment `.../attachments/228/content` endpoints) are now downloaded as binary assets. Previously such references were skipped during discovery while still being rewritten to a local path, leaving a broken link — and older versions mis-classified them as HTML pages and corrupted the file during text decoding. ([#49](https://github.com/PKHarsimran/website-downloader/issues/49))
+- Images and media referenced from extensionless URLs (e.g. OpenProject attachment `.../attachments/228/content` endpoints) are now downloaded as binary assets, and matching `srcset` candidates are rewritten to the local copy. Previously such references were skipped during discovery while still being rewritten to a local path, leaving a broken link — and older versions mis-classified them as HTML pages and corrupted the file during text decoding. ([#49](https://github.com/PKHarsimran/website-downloader/issues/49))
 
 ## v2.6.0 - 2026-07-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "website-downloader"
-version = "2.6.0"
+version = "2.6.1"
 description = "A Python CLI for mirroring websites into browsable offline copies."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/website_downloader/__init__.py
+++ b/website_downloader/__init__.py
@@ -1,3 +1,3 @@
 """Website Downloader package."""
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"


### PR DESCRIPTION
Version bump to **2.6.1** (`pyproject.toml`, `website_downloader/__init__.py`) and the changelog `Unreleased` section is now dated `v2.6.1 - 2026-07-08`.

Ships the extensionless-attachment fix from #50 (closes #49). Once merged, the `v2.6.1` tag and GitHub release publish automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)