### PR TITLE
Add commercial licensing note and contributor CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,62 @@
+# Contributor License Agreement
+
+Thank you for contributing to Website Downloader CLI (the "Project").
+
+This Contributor License Agreement ("Agreement") clarifies the rights granted by
+contributors so the Project can be maintained, distributed, and licensed with
+confidence. It is intentionally short. You keep the copyright to your work — you
+are simply granting the Project a broad license to use it.
+
+By submitting a contribution (code, documentation, or other material) to the
+Project — for example by opening a pull request — you agree to the following.
+
+## 1. Definitions
+
+- "You" means the individual or legal entity making a Contribution.
+- "Contribution" means any original work of authorship that You intentionally
+  submit to the Project.
+- "Maintainer" means Harsimran Sidhu, the copyright holder of the Project.
+
+## 2. Copyright
+
+You retain ownership of the copyright in Your Contribution. This Agreement does
+not transfer ownership.
+
+## 3. Copyright license grant
+
+You grant the Maintainer and recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license
+to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contribution and such derivative works.
+
+You agree that the Maintainer may license and relicense Your Contribution,
+including under different or additional terms (for example, a commercial or
+dual-license offering), provided the Contribution also remains available under
+the Project's open-source license.
+
+## 4. Patent license grant
+
+You grant the Maintainer and recipients of the software a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable patent license to make, use, sell,
+offer to sell, import, and otherwise transfer Your Contribution, where such
+license applies only to patent claims licensable by You that are necessarily
+infringed by Your Contribution alone or by its combination with the Project.
+
+## 5. Your representations
+
+You represent that:
+
+- Each Contribution is Your original creation, or You have the right to submit
+  it under this Agreement.
+- If Your employer has rights to intellectual property You create, You have
+  received permission to make the Contribution on behalf of that employer, or
+  the employer has waived such rights.
+
+## 6. Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contribution "AS IS", without warranties or conditions of any kind.
+
+---
+
+If You do not agree to these terms, please do not submit a Contribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Harsimran Sidhu
+Copyright (c) 2024-2026 Harsimran Sidhu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -355,12 +355,20 @@ Only mirror sites you own, have permission to archive, or are legally allowed to
 
 Contributions are welcome! Open an issue or pull request for bug reports, feature ideas, or improvements. The codebase is intentionally small and modular — most features live in a single focused module, so it's an easy project to hack on.
 
+By submitting a contribution, you agree to the [Contributor License Agreement](CLA.md): you keep the copyright to your work and license it to the project so it can be maintained and distributed (including under future licensing terms).
+
 If this tool saved you time, consider **starring the repo** ⭐ — it helps others find it.
 
 ## ☕ Support This Project
 
 [Donate via PayPal](https://www.paypal.com/donate/?business=PJVPSXG6V4CUG&no_recurring=1&item_name=Thank+you+for+the+coffee+%3A%29&currency_code=CAD)
 
-## 📄 License
+## 📄 License & Ownership
 
-MIT — use it, fork it, ship it. See [LICENSE](LICENSE) for details.
+This project is released under the [MIT License](LICENSE) — free to use, fork, modify, and ship, including in commercial products, as long as the copyright and license notice are kept.
+
+The copyright is owned by Harsimran Sidhu. The MIT license grants broad permission to use the code; it does not transfer ownership. The name "Website Downloader CLI" and any associated branding are not covered by the code license.
+
+### Commercial use, hosting, and support
+
+The open-source license already covers most commercial use. If you'd like something the MIT license doesn't provide — a **commercial/OEM license** with different terms, a **hosted or managed version**, **priority support**, or **custom features** — reach out via a [GitHub issue](https://github.com/PKHarsimran/website-downloader/issues) or the contact on the maintainer's [GitHub profile](https://github.com/PKHarsimran).


### PR DESCRIPTION
Prepares the project for future monetization **without changing the open-source terms** or touching the standard MIT text.

## Changes
- **LICENSE:** copyright year range extended to `2024-2026`. The MIT license body is unchanged and remains the standard, recognized license.
- **README → "License & Ownership":** clarifies that the maintainer owns the copyright, MIT covers open use, the name/brand is separate from the code license, and how to reach out for a **commercial license, hosted version, or support**.
- **CLA.md:** a Contributor License Agreement — contributors keep their copyright but grant the project a broad license, **preserving the option to dual-license or relicense later**. Noted in the Contributing section.

## Why
MIT already allows commercial use, so this doesn't restrict anything today. The CLA is the key future-proofing step: without it, relicensing later would require chasing down every past contributor's consent.

## Manual follow-up (not in this PR)
To actually enforce the CLA on new PRs, install the free **CLA Assistant** GitHub app and point it at `CLA.md` — that's a one-time settings action only the repo owner can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)