### PR TITLE
Add Wiki and PyPI links to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 *A modern, hackable alternative to `wget --mirror` and HTTrack — built in pure Python, without dragging in a heavy crawler framework.*
 
+📖 **[Read the Wiki](https://github.com/PKHarsimran/website-downloader/wiki)** — full CLI reference, cookbook, and troubleshooting · 📦 **[Install from PyPI](https://pypi.org/project/website-downloader/)**
+
 </div>
 
 ---


### PR DESCRIPTION
Adds a centered **Read the Wiki** + **Install from PyPI** line directly under the tagline in the README header.

The wiki was just rebuilt with full v2.6 coverage (CLI reference, cookbook, JavaScript rendering, incremental updates, exports, troubleshooting/FAQ, contributing), but nothing in the README pointed to it — this makes it discoverable in the first screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)