### PR TITLE
Add --exclude/--exclude-file page blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `--exclude` / `--exclude-file` skip pages whose URL matches a glob pattern (e.g. `*/forum/*`), so unwanted sections of a site (forums, drafts, etc.) are no longer crawled. ([#55](https://github.com/PKHarsimran/website-downloader/issues/55))
+
 ## v2.6.1 - 2026-07-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -202,6 +202,29 @@ Point at a custom sitemap URL or local sitemap file:
 website-downloader --url https://example.com --sitemap https://example.com/sitemap.xml
 ```
 
+Skip parts of a site you don't want mirrored (e.g. a forum bolted onto a site you're archiving):
+
+```bash
+website-downloader ^
+  --url https://example.com ^
+  --destination example_backup ^
+  --exclude "*/forum/*" ^
+  --exclude "*/drafts/*"
+```
+
+Patterns are glob-style (`fnmatch`) and match against both the full URL and the path, so `/forum/*`
+and `*/forum/*` both work. Load a longer list from a file instead of repeating `--exclude`:
+
+```bash
+website-downloader --url https://example.com --exclude-file exclude-patterns.txt
+```
+
+```text
+# exclude-patterns.txt
+*/forum/*
+*/drafts/*
+```
+
 Use safer crawl limits:
 
 ```bash
@@ -269,6 +292,7 @@ If `rich` is not installed, the crawler falls back to normal logging instead of 
 | `--header` | Adds custom request headers. | Bearer tokens, staging headers, API gateway headers. |
 | `--update` | Reuses cache metadata and skips unchanged resources when the server supports it. | Recurring mirrors and archives. |
 | `--sitemap` | Seeds the crawl from `sitemap.xml` or a supplied sitemap. | Faster, more complete discovery. |
+| `--exclude` / `--exclude-file` | Skips pages whose URL matches a glob pattern. | Ignoring forums, drafts, or other sections you don't want mirrored. |
 | `--progress` | Shows a Rich terminal progress dashboard when installed. | Long crawls where visibility matters. |
 | `--zip-output` | Exports the mirror folder as a zip. | Sharing, attaching, or storing snapshots. |
 | `--warc-output` | Writes a simple WARC response archive. | Archival workflows and future replay tooling. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,29 @@ def attachment_site(tmp_path: Path) -> Iterator[tuple[str, Path, bytes]]:
 
 
 @pytest.fixture
+def blacklist_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    """Site with a forum subsection that a blacklist pattern can exclude."""
+    site = tmp_path / "blacklist-site"
+    (site / "forum").mkdir(parents=True)
+    (site / "index.html").write_text(
+        """
+        <html><body>
+          <a href="/about.html">About</a>
+          <a href="/forum/thread1.html">Forum Thread</a>
+        </body></html>
+        """,
+        encoding="utf-8",
+    )
+    (site / "about.html").write_text("<html><body>About</body></html>", encoding="utf-8")
+    (site / "forum" / "thread1.html").write_text(
+        "<html><body>Forum thread</body></html>", encoding="utf-8"
+    )
+
+    with serve_directory(site) as base_url:
+        yield base_url, site
+
+
+@pytest.fixture
 def conditional_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
     site = tmp_path / "conditional-site"
     site.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import pytest
 
 from website_downloader.cli import (
     load_cookies,
+    load_exclude_patterns,
     load_headers,
     parse_args,
     parse_cookie_header,
@@ -56,3 +57,20 @@ def test_load_headers_uses_last_repeated_header() -> None:
 def test_headless_alias_enables_flag() -> None:
     args = parse_args(["--url", "https://example.com", "--headless"])
     assert args.headless is True
+
+
+def test_parse_args_collects_repeated_exclude_patterns() -> None:
+    args = parse_args(
+        ["--url", "https://example.com", "--exclude", "*/forum/*", "--exclude", "*/drafts/*"]
+    )
+    assert args.exclude == ["*/forum/*", "*/drafts/*"]
+
+
+def test_load_exclude_patterns_merges_files_and_cli(tmp_path) -> None:
+    pattern_file = tmp_path / "exclude.txt"
+    pattern_file.write_text("# comment\n*/forum/*\n\n*/drafts/*\n", encoding="utf-8")
+    assert load_exclude_patterns(["*/admin/*"], [str(pattern_file)]) == [
+        "*/admin/*",
+        "*/forum/*",
+        "*/drafts/*",
+    ]

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -86,6 +86,25 @@ def test_crawl_downloads_extensionless_attachment_image(attachment_site, tmp_pat
     assert not (output / "attachments" / "228" / "content.html").exists()
 
 
+def test_crawl_site_skips_blacklisted_pages(blacklist_site, tmp_path: Path) -> None:
+    base_url, _site = blacklist_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=10,
+            exclude_patterns=["*/forum/*"],
+        )
+    )
+
+    assert stats.pages_seen == 2
+    assert (output / "index.html").exists()
+    assert (output / "about.html").exists()
+    assert not (output / "forum" / "thread1.html").exists()
+
+
 def test_crawl_site_uses_sitemap_seed(local_site, tmp_path: Path) -> None:
     base_url, _site = local_site
     output = tmp_path / "mirror"

--- a/tests/test_urltools.py
+++ b/tests/test_urltools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from website_downloader.urltools import (
     canonicalize_url,
     is_allowed_external,
+    is_blacklisted,
     is_internal,
     normalize_external_domains,
 )
@@ -24,3 +25,15 @@ def test_external_domain_whitelist_accepts_subdomains() -> None:
     assert domains == {"cdn.example.com", "assets.test"}
     assert is_allowed_external("https://img.cdn.example.com/a.png", domains)
     assert not is_allowed_external("https://example.org/a.png", domains)
+
+
+def test_is_blacklisted_matches_path_glob_regardless_of_host() -> None:
+    patterns = ["*/forum/*"]
+    assert is_blacklisted("https://example.com/forum/thread/1", patterns)
+    assert is_blacklisted("/forum/thread/1", patterns)
+    assert not is_blacklisted("https://example.com/blog/post", patterns)
+
+
+def test_is_blacklisted_returns_false_without_patterns() -> None:
+    assert not is_blacklisted("https://example.com/forum/thread/1", None)
+    assert not is_blacklisted("https://example.com/forum/thread/1", [])

--- a/website_downloader/cli.py
+++ b/website_downloader/cli.py
@@ -109,6 +109,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--delay", type=float, default=0.0, help="Delay in seconds between page fetches."
     )
     parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help=(
+            "Skip pages whose URL matches this glob pattern (e.g. '*/forum/*' or "
+            "'/blog/drafts/*'). Can be repeated."
+        ),
+    )
+    parser.add_argument(
+        "--exclude-file",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help="Read exclude glob patterns from a file, one per line ('#' comments allowed).",
+    )
+    parser.add_argument(
         "--max-asset-bytes",
         type=int,
         default=None,
@@ -203,6 +220,17 @@ def load_headers(header_values: list[str]) -> dict[str, str]:
     return headers
 
 
+def load_exclude_patterns(patterns: list[str], pattern_files: list[str]) -> list[str]:
+    combined = list(patterns)
+    for pattern_path in pattern_files:
+        raw = Path(pattern_path).expanduser().read_text(encoding="utf-8")
+        for line in raw.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                combined.append(line)
+    return combined
+
+
 def validate_args(args: argparse.Namespace) -> None:
     if args.max_pages < 1:
         raise ValueError("--max-pages must be >= 1")
@@ -227,6 +255,7 @@ def main(argv: list[str] | None = None) -> int:
         validate_args(args)
         cookies = load_cookies(args.cookie, args.cookie_file)
         headers = load_headers(args.header)
+        exclude_patterns = load_exclude_patterns(args.exclude, args.exclude_file)
     except (OSError, ValueError) as exc:
         log.error("%s", exc)
         return 2
@@ -241,6 +270,7 @@ def main(argv: list[str] | None = None) -> int:
         page_threads=args.page_threads,
         download_external_assets=download_external_assets,
         external_domains=normalize_external_domains(args.external_domains),
+        exclude_patterns=exclude_patterns or None,
         cookies=cookies,
         headers=headers,
         delay=args.delay,

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -24,6 +24,7 @@ from .urltools import (
     canonical_netloc,
     canonicalize_url,
     is_allowed_external,
+    is_blacklisted,
     is_httpish,
     is_internal,
     is_non_fetchable,
@@ -49,6 +50,7 @@ class CrawlOptions:
     page_threads: int = 1
     download_external_assets: bool = False
     external_domains: set[str] | None = None
+    exclude_patterns: list[str] | None = None
     cookies: dict[str, str] | None = None
     headers: dict[str, str] | None = None
     timeout: int = TIMEOUT
@@ -131,6 +133,9 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
 
     def enqueue_page(url: str) -> None:
         normalized = canonicalize_url(url, start_url)
+        if is_blacklisted(normalized, options.exclude_patterns):
+            log.debug("Excluded page (blacklist match): %s", normalized)
+            return
         with page_lock:
             if normalized not in queued_pages and normalized not in seen_pages:
                 q_pages.put(normalized)

--- a/website_downloader/urltools.py
+++ b/website_downloader/urltools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 from urllib.parse import ParseResult, urljoin, urlparse
 
 from .constants import NON_FETCHABLE_SCHEMES
@@ -74,6 +75,20 @@ def is_allowed_external(url: str, allowed_domains: set[str] | None) -> bool:
         return True
     host = (urlparse(url).hostname or "").lower()
     return any(host == domain or host.endswith("." + domain) for domain in allowed_domains)
+
+
+def is_blacklisted(url: str, patterns: list[str] | None) -> bool:
+    """Check a URL against glob patterns (fnmatch syntax, e.g. '*/forum/*').
+
+    Patterns are matched against both the full URL and the path alone, so
+    '/forum/*' and 'https://example.com/forum/*' both work regardless of host.
+    """
+    if not patterns:
+        return False
+    path = urlparse(url).path or "/"
+    return any(
+        fnmatch.fnmatch(url, pattern) or fnmatch.fnmatch(path, pattern) for pattern in patterns
+    )
 
 
 def normalize_external_domains(domains: list[str] | None) -> set[str] | None:


### PR DESCRIPTION
Closes #55.

Adds a way to skip parts of a site during a crawl instead of wasting time and disk space mirroring pages nobody wants offline (e.g. a forum bolted onto a site being archived).

## Changes
- `--exclude PATTERN` (repeatable) and `--exclude-file FILE` CLI options
- Patterns are glob-style (fnmatch), matched against both the full URL and the path, so `*/forum/*` or `/forum/*` both work
- Blacklisted URLs are skipped at the page-enqueue step, so nothing under them (including their assets) gets crawled
- Tests for is_blacklisted, CLI parsing/file loading, and an end-to-end crawler test
- README cookbook entry + feature table row, CHANGELOG entry

## Test plan
- pytest -q (39 passed)
- black --check, isort --check-only, ruff check, flake8 all clean