### PR TITLE
Preserve live URL for links to excluded pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `--exclude` / `--exclude-file` skip pages whose URL matches a glob pattern (e.g. `*/forum/*`), so unwanted sections of a site (forums, drafts, etc.) are no longer crawled. ([#55](https://github.com/PKHarsimran/website-downloader/issues/55))
 
+### Fixed
+
+- Links to excluded pages are now saved pointing at the live URL instead of a local path that was never downloaded, which previously left a broken link in the offline mirror. ([#55](https://github.com/PKHarsimran/website-downloader/issues/55))
+
 ## v2.6.1 - 2026-07-08
 
 ### Fixed

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -104,6 +104,11 @@ def test_crawl_site_skips_blacklisted_pages(blacklist_site, tmp_path: Path) -> N
     assert (output / "about.html").exists()
     assert not (output / "forum" / "thread1.html").exists()
 
+    html = (output / "index.html").read_text(encoding="utf-8")
+    # The excluded page was never downloaded, so the saved link must point at
+    # the live URL instead of a local path that doesn't exist.
+    assert f'href="{base_url}forum/thread1.html"' in html
+
 
 def test_crawl_site_uses_sitemap_seed(local_site, tmp_path: Path) -> None:
     base_url, _site = local_site

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -146,5 +146,37 @@ def test_rewrite_links_keeps_absolute_url_for_excluded_pages(tmp_path: Path) -> 
     assert links[1]["href"] == "about.html"
 
 
+def test_rewrite_links_preserves_fragment_for_excluded_pages(tmp_path: Path) -> None:
+    soup = BeautifulSoup('<a href="/forum/thread#reply-3">Reply</a>', "html.parser")
+    rewrite_links(
+        soup,
+        "https://example.com/index.html",
+        tmp_path,
+        tmp_path,
+        download_external_assets=False,
+        exclude_patterns=["*/forum/*"],
+    )
+
+    assert soup.find("a")["href"] == "https://example.com/forum/thread#reply-3"
+
+
+def test_rewrite_links_keeps_local_path_for_downloaded_asset_matching_exclude(
+    tmp_path: Path,
+) -> None:
+    # "*/forum/*" also matches this asset link, but the crawler still
+    # downloads it (only pages are excluded), so the local path must be kept.
+    soup = BeautifulSoup('<a href="/forum/logo.png">Logo</a>', "html.parser")
+    rewrite_links(
+        soup,
+        "https://example.com/index.html",
+        tmp_path,
+        tmp_path,
+        download_external_assets=False,
+        exclude_patterns=["*/forum/*"],
+    )
+
+    assert soup.find("a")["href"] == "forum/logo.png"
+
+
 def test_canonical_netloc_import_keeps_public_api_available() -> None:
     assert canonical_netloc(urlparse("https://EXAMPLE.com:443/a")) == "example.com"

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -125,5 +125,26 @@ def test_rewrite_external_asset_strips_sri(tmp_path: Path) -> None:
     assert "crossorigin" not in script.attrs
 
 
+def test_rewrite_links_keeps_absolute_url_for_excluded_pages(tmp_path: Path) -> None:
+    soup = BeautifulSoup(
+        '<a href="/forum/thread1">Forum</a><a href="/about">About</a>',
+        "html.parser",
+    )
+    rewrite_links(
+        soup,
+        "https://example.com/index.html",
+        tmp_path,
+        tmp_path,
+        download_external_assets=False,
+        exclude_patterns=["*/forum/*"],
+    )
+
+    links = soup.find_all("a")
+    # The excluded page was never downloaded, so it must keep pointing at the
+    # live URL instead of a local path that doesn't exist.
+    assert links[0]["href"] == "https://example.com/forum/thread1"
+    assert links[1]["href"] == "about.html"
+
+
 def test_canonical_netloc_import_keeps_public_api_available() -> None:
     assert canonical_netloc(urlparse("https://EXAMPLE.com:443/a")) == "example.com"

--- a/website_downloader/constants.py
+++ b/website_downloader/constants.py
@@ -92,6 +92,8 @@ DEFAULT_HEADERS = {
     "Upgrade-Insecure-Requests": "1",
 }
 
+PAGE_SUFFIXES = {"", ".html", ".htm"}
+
 TIMEOUT = 15
 CHUNK_SIZE = 8192
 MAX_PATH_LEN = 240

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
 
 from .cache import CrawlCache
-from .constants import ASSET_EXTENSIONS, DEFAULT_USER_AGENT, TIMEOUT
+from .constants import ASSET_EXTENSIONS, DEFAULT_USER_AGENT, PAGE_SUFFIXES, TIMEOUT
 from .exports import SavedResource, create_zip_archive, write_warc
 from .http import create_session, fetch_binary, fetch_html
 from .paths import cdn_local_path, create_dir, safe_write_text, to_local_asset_path, to_local_path
@@ -31,8 +31,6 @@ from .urltools import (
 )
 
 log = logging.getLogger(__name__)
-
-PAGE_SUFFIXES = {"", ".html", ".htm"}
 
 # Tags whose asset references are downloaded even when the URL has no file
 # extension. Media served from extensionless endpoints (e.g. OpenProject

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -267,6 +267,7 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                             local_path.parent,
                             options.download_external_assets,
                             options.external_domains,
+                            options.exclude_patterns,
                         )
                         safe_write_text(local_path, str(result.soup), encoding="utf-8")
                         with stats_lock:

--- a/website_downloader/rewrite.py
+++ b/website_downloader/rewrite.py
@@ -21,6 +21,7 @@ from .urltools import (
     canonical_netloc,
     canonicalize_url,
     is_allowed_external,
+    is_blacklisted,
     is_httpish,
     is_internal,
     is_non_fetchable,
@@ -189,6 +190,7 @@ def rewrite_links(
     page_dir: Path,
     download_external_assets: bool = False,
     external_domains: set[str] | None = None,
+    exclude_patterns: list[str] | None = None,
 ) -> None:
     root_netloc = canonical_netloc(urlparse(page_url))
 
@@ -234,6 +236,12 @@ def rewrite_links(
             is_ext = not is_internal(abs_url, root_netloc)
             treat_as_page = tag.name == "a" and attr == "href"
             rewritten_external_asset = False
+
+            if treat_as_page and not is_ext and is_blacklisted(abs_url, exclude_patterns):
+                # This page was never crawled, so there is no local file to
+                # link to. Point at the live URL instead of a broken local path.
+                tag[attr] = abs_url
+                continue
 
             if is_ext and treat_as_page:
                 continue

--- a/website_downloader/rewrite.py
+++ b/website_downloader/rewrite.py
@@ -14,6 +14,7 @@ from .constants import (
     CSS_URL_RE,
     JS_ABS_URL_RE,
     JS_URL_RE,
+    PAGE_SUFFIXES,
     RESOURCE_LINK_RELS,
 )
 from .paths import cdn_local_path, rel_url, to_local_asset_path, to_local_path
@@ -237,10 +238,23 @@ def rewrite_links(
             treat_as_page = tag.name == "a" and attr == "href"
             rewritten_external_asset = False
 
-            if treat_as_page and not is_ext and is_blacklisted(abs_url, exclude_patterns):
+            # Mirrors the crawler's own page-vs-asset classification, so an
+            # excluded glob that happens to also match a downloaded asset
+            # link (e.g. "*/forum/*" matching "/forum/logo.png") does not
+            # get rewritten away from its local copy.
+            suffix = Path(parsed.path).suffix.lower()
+            crawled_as_page = (
+                treat_as_page
+                and not is_ext
+                and (parsed.path.endswith("/") or suffix in PAGE_SUFFIXES)
+            )
+
+            if crawled_as_page and is_blacklisted(abs_url, exclude_patterns):
                 # This page was never crawled, so there is no local file to
-                # link to. Point at the live URL instead of a broken local path.
-                tag[attr] = abs_url
+                # link to. Point at the live URL instead of a broken local
+                # path, preserving the fragment canonicalize_url stripped.
+                fragment = urlparse(original).fragment
+                tag[attr] = f"{abs_url}#{fragment}" if fragment else abs_url
                 continue
 
             if is_ext and treat_as_page:


### PR DESCRIPTION
Follow-up to #57. The automated Codex review on that PR flagged that excluded pages were correctly skipped from the crawl queue, but rewrite_links() still rewrote <a href> references to them into local paths, producing a broken link in the saved mirror since the file was never downloaded.

## Changes
- rewrite_links() takes an exclude_patterns param; when an internal <a href> target matches a pattern, its href is left as the absolute live URL instead of a local path
- Wired through from crawl_site() via options.exclude_patterns
- Test in test_rewrite.py for the rewrite behavior directly, plus an assertion added to the existing crawler blacklist test

## Test plan
- pytest -q (38 passed)
- black --check, isort --check-only, ruff check, flake8 all clean