### PR TITLE
Add multi-URL seeding (--url-file) and --max-depth crawl limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `--exclude` / `--exclude-file` skip pages whose URL matches a glob pattern (e.g. `*/forum/*`), so unwanted sections of a site (forums, drafts, etc.) are no longer crawled. ([#55](https://github.com/PKHarsimran/website-downloader/issues/55))
+- `--url` can now be repeated, and `--url-file` seeds additional starting URLs from a text file, so one crawl can mirror several sections of a site instead of only a single starting page. ([#56](https://github.com/PKHarsimran/website-downloader/issues/56))
+- `--max-depth` limits how many link-hops are followed from each starting URL, keeping crawls focused instead of relying solely on `--max-pages`. ([#56](https://github.com/PKHarsimran/website-downloader/issues/56))
 
 ## v2.6.1 - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,31 @@ website-downloader ^
   --header "X-Environment: staging"
 ```
 
+Mirror several starting points on the same site, following links up to 2 levels deep from each:
+
+```bash
+website-downloader ^
+  --url https://example.com/docs/ ^
+  --url https://example.com/blog/ ^
+  --destination example_backup ^
+  --max-depth 2
+```
+
+`--url` can be repeated, or supplied from a file instead:
+
+```bash
+website-downloader --url-file starting-urls.txt --destination example_backup --max-depth 2
+```
+
+```text
+# starting-urls.txt
+https://example.com/docs/
+https://example.com/blog/
+```
+
+`--max-depth` counts links away from each starting URL (`0` mirrors only the starting URLs
+themselves); omit it for unlimited depth, bounded only by `--max-pages`.
+
 Use a sitemap as the crawl seed:
 
 ```bash
@@ -286,6 +311,8 @@ If `rich` is not installed, the crawler falls back to normal logging instead of 
 
 | Flag | What it does | Best for |
 | --- | --- | --- |
+| `--url` (repeatable) / `--url-file` | Seeds the crawl from multiple starting URLs. | Mirroring several sections of a site in one run. |
+| `--max-depth` | Limits how many link-hops are followed from each starting URL. | Staying focused near your starting points instead of crawling the whole site. |
 | `--page-threads` | Fetches HTML pages concurrently (default 1). | Faster mirroring of large sites that tolerate concurrent requests. |
 | `--render-js` / `--headless` | Uses Playwright before parsing the page. | React, Vue, Angular, Next.js, and other client-rendered sites. |
 | `--cookie-file` | Sends saved browser/session cookies. | Authorized portals, staging sites, docs behind login. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,43 @@ def blacklist_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
 
 
 @pytest.fixture
+def depth_chain_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    """Site with a linear link chain: index -> level1 -> level2 -> level3."""
+    site = tmp_path / "depth-chain-site"
+    site.mkdir()
+    (site / "index.html").write_text(
+        '<html><body><a href="/level1.html">L1</a></body></html>', encoding="utf-8"
+    )
+    (site / "level1.html").write_text(
+        '<html><body><a href="/level2.html">L2</a></body></html>', encoding="utf-8"
+    )
+    (site / "level2.html").write_text(
+        '<html><body><a href="/level3.html">L3</a></body></html>', encoding="utf-8"
+    )
+    (site / "level3.html").write_text("<html><body>Leaf</body></html>", encoding="utf-8")
+
+    with serve_directory(site) as base_url:
+        yield base_url, site
+
+
+@pytest.fixture
+def multi_seed_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    """Site with two disconnected sections, only reachable as separate seeds."""
+    site = tmp_path / "multi-seed-site"
+    (site / "docs").mkdir(parents=True)
+    (site / "blog").mkdir()
+    (site / "docs" / "index.html").write_text(
+        "<html><body>Docs home</body></html>", encoding="utf-8"
+    )
+    (site / "blog" / "index.html").write_text(
+        "<html><body>Blog home</body></html>", encoding="utf-8"
+    )
+
+    with serve_directory(site) as base_url:
+        yield base_url, site
+
+
+@pytest.fixture
 def conditional_site(tmp_path: Path) -> Iterator[tuple[str, Path]]:
     site = tmp_path / "conditional-site"
     site.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from website_downloader.cli import (
     load_cookies,
     load_exclude_patterns,
     load_headers,
+    load_start_urls,
     parse_args,
     parse_cookie_header,
     parse_header,
@@ -74,3 +75,38 @@ def test_load_exclude_patterns_merges_files_and_cli(tmp_path) -> None:
         "*/forum/*",
         "*/drafts/*",
     ]
+
+
+def test_parse_args_collects_repeated_urls() -> None:
+    args = parse_args(["--url", "https://example.com/a", "--url", "https://example.com/b"])
+    assert args.url == ["https://example.com/a", "https://example.com/b"]
+
+
+def test_load_start_urls_merges_file_and_dedupes(tmp_path) -> None:
+    url_file = tmp_path / "urls.txt"
+    url_file.write_text(
+        "# comment\nhttps://example.com/a\n\nhttps://example.com/c\n",
+        encoding="utf-8",
+    )
+    result = load_start_urls(["https://example.com/a", "https://example.com/b"], str(url_file))
+    assert result == [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+
+
+def test_load_start_urls_raises_without_any_url() -> None:
+    with pytest.raises(ValueError):
+        load_start_urls([], None)
+
+
+def test_validate_args_rejects_negative_max_depth() -> None:
+    args = parse_args(["--url", "https://example.com", "--max-depth", "-1"])
+    with pytest.raises(ValueError):
+        validate_args(args)
+
+
+def test_validate_args_accepts_zero_max_depth() -> None:
+    args = parse_args(["--url", "https://example.com", "--max-depth", "0"])
+    validate_args(args)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -105,6 +105,80 @@ def test_crawl_site_skips_blacklisted_pages(blacklist_site, tmp_path: Path) -> N
     assert not (output / "forum" / "thread1.html").exists()
 
 
+def test_crawl_site_respects_max_depth(depth_chain_site, tmp_path: Path) -> None:
+    base_url, _site = depth_chain_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=10,
+            max_depth=1,
+        )
+    )
+
+    assert stats.pages_seen == 2
+    assert (output / "index.html").exists()
+    assert (output / "level1.html").exists()
+    assert not (output / "level2.html").exists()
+    assert not (output / "level3.html").exists()
+
+
+def test_crawl_site_max_depth_zero_only_fetches_seeds(depth_chain_site, tmp_path: Path) -> None:
+    base_url, _site = depth_chain_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=10,
+            max_depth=0,
+        )
+    )
+
+    assert stats.pages_seen == 1
+    assert (output / "index.html").exists()
+    assert not (output / "level1.html").exists()
+
+
+def test_crawl_site_unlimited_depth_follows_full_chain(depth_chain_site, tmp_path: Path) -> None:
+    base_url, _site = depth_chain_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=base_url,
+            root=output,
+            max_pages=10,
+        )
+    )
+
+    assert stats.pages_seen == 4
+    assert (output / "level3.html").exists()
+
+
+def test_crawl_site_extra_start_urls_seed_disconnected_sections(
+    multi_seed_site, tmp_path: Path
+) -> None:
+    base_url, _site = multi_seed_site
+    output = tmp_path / "mirror"
+
+    stats = crawl_site(
+        CrawlOptions(
+            start_url=f"{base_url}docs/",
+            extra_start_urls=[f"{base_url}blog/"],
+            root=output,
+            max_pages=10,
+        )
+    )
+
+    assert stats.pages_seen == 2
+    assert (output / "docs" / "index.html").exists()
+    assert (output / "blog" / "index.html").exists()
+
+
 def test_crawl_site_uses_sitemap_seed(local_site, tmp_path: Path) -> None:
     base_url, _site = local_site
     output = tmp_path / "mirror"

--- a/website_downloader/cli.py
+++ b/website_downloader/cli.py
@@ -56,13 +56,33 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Recursively mirror a website for offline use.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--url", required=True, help="Starting URL to crawl.")
+    parser.add_argument(
+        "--url",
+        action="append",
+        default=[],
+        help="Starting URL to crawl. Can be repeated for multiple starting points.",
+    )
+    parser.add_argument(
+        "--url-file",
+        default=None,
+        metavar="FILE",
+        help="Read additional starting URLs from a text file, one per line ('#' comments allowed).",
+    )
     parser.add_argument(
         "--destination",
         default=None,
-        help="Output folder. Defaults to a folder derived from the URL.",
+        help="Output folder. Defaults to a folder derived from the first URL.",
     )
     parser.add_argument("--max-pages", type=int, default=50, help="Maximum HTML pages to crawl.")
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=None,
+        help=(
+            "Maximum link depth to follow from each starting URL (0 = only the starting "
+            "URLs themselves). Omit for unlimited depth, bounded only by --max-pages."
+        ),
+    )
     parser.add_argument("--threads", type=int, default=6, help="Concurrent asset download workers.")
     parser.add_argument(
         "--page-threads",
@@ -231,9 +251,32 @@ def load_exclude_patterns(patterns: list[str], pattern_files: list[str]) -> list
     return combined
 
 
+def load_start_urls(urls: list[str], url_file: str | None) -> list[str]:
+    combined = list(urls)
+    if url_file:
+        raw = Path(url_file).expanduser().read_text(encoding="utf-8")
+        for line in raw.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                combined.append(line)
+
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for url in combined:
+        if url not in seen:
+            seen.add(url)
+            deduped.append(url)
+
+    if not deduped:
+        raise ValueError("At least one --url (or --url-file entry) is required")
+    return deduped
+
+
 def validate_args(args: argparse.Namespace) -> None:
     if args.max_pages < 1:
         raise ValueError("--max-pages must be >= 1")
+    if args.max_depth is not None and args.max_depth < 0:
+        raise ValueError("--max-depth must be >= 0")
     if args.threads < 1:
         raise ValueError("--threads must be >= 1")
     if args.page_threads < 1:
@@ -253,6 +296,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         validate_args(args)
+        start_urls = load_start_urls(args.url, args.url_file)
         cookies = load_cookies(args.cookie, args.cookie_file)
         headers = load_headers(args.header)
         exclude_patterns = load_exclude_patterns(args.exclude, args.exclude_file)
@@ -263,9 +307,11 @@ def main(argv: list[str] | None = None) -> int:
     download_external_assets = args.download_external_assets or args.external_domains is not None
     render_js = args.render_js or args.headless
     options = CrawlOptions(
-        start_url=args.url,
-        root=make_root(args.url, args.destination),
+        start_url=start_urls[0],
+        extra_start_urls=start_urls[1:],
+        root=make_root(start_urls[0], args.destination),
         max_pages=args.max_pages,
+        max_depth=args.max_depth,
         threads=args.threads,
         page_threads=args.page_threads,
         download_external_assets=download_external_assets,

--- a/website_downloader/crawler.py
+++ b/website_downloader/crawler.py
@@ -6,7 +6,7 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
@@ -45,7 +45,9 @@ EXTENSIONLESS_ASSET_TAGS = {"script", "link", "img", "source", "video", "audio",
 class CrawlOptions:
     start_url: str
     root: Path
+    extra_start_urls: list[str] = field(default_factory=list)
     max_pages: int = 50
+    max_depth: int | None = None
     threads: int = 6
     page_threads: int = 1
     download_external_assets: bool = False
@@ -82,7 +84,7 @@ class CrawlStats:
 
 
 def crawl_site(options: CrawlOptions) -> CrawlStats:
-    q_pages: queue.Queue[str] = queue.Queue()
+    q_pages: queue.Queue[tuple[str, int]] = queue.Queue()
     start_url = canonicalize_url(options.start_url)
     seen_pages: set[str] = set()
     queued_pages: set[str] = set()
@@ -131,14 +133,16 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
     crawl_cache = CrawlCache.load(cache_path) if options.update else CrawlCache()
     stats = CrawlStats(pages_seen=0, assets_queued=0, elapsed_seconds=0.0)
 
-    def enqueue_page(url: str) -> None:
+    def enqueue_page(url: str, depth: int = 0) -> None:
+        if options.max_depth is not None and depth > options.max_depth:
+            return
         normalized = canonicalize_url(url, start_url)
         if is_blacklisted(normalized, options.exclude_patterns):
             log.debug("Excluded page (blacklist match): %s", normalized)
             return
         with page_lock:
             if normalized not in queued_pages and normalized not in seen_pages:
-                q_pages.put(normalized)
+                q_pages.put((normalized, depth))
                 queued_pages.add(normalized)
 
     def enqueue_asset(url: str, dest: Path) -> None:
@@ -153,6 +157,8 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
         download_q.put((abs_url, dest))
 
     enqueue_page(start_url)
+    for extra_url in options.extra_start_urls:
+        enqueue_page(canonicalize_url(extra_url))
     if options.update:
         # Saved pages contain rewritten local links, so a 304 page cannot be
         # re-discovered from its own HTML. Seed known pages from the cache.
@@ -224,7 +230,10 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                 progress.page_seen(claimed, options.max_pages, page_url)
                 return True
 
-            def process_page(page_url: str) -> None:
+            def process_page(page_url: str, depth: int) -> None:
+                def enqueue_child_page(url: str) -> None:
+                    enqueue_page(url, depth + 1)
+
                 try:
                     local_path = to_local_path(urlparse(page_url), options.root)
                     result = fetch_html(
@@ -255,7 +264,7 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
                             page_url=page_url,
                             root=options.root,
                             root_netloc=root_netloc,
-                            enqueue_page=enqueue_page,
+                            enqueue_page=enqueue_child_page,
                             enqueue_asset=enqueue_asset,
                             options=options,
                         )
@@ -302,9 +311,9 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
             if page_threads == 1:
                 # Inline path keeps Playwright rendering on this thread.
                 while not q_pages.empty() and len(seen_pages) < options.max_pages:
-                    page_url = q_pages.get()
+                    page_url, depth = q_pages.get()
                     if claim_page(page_url):
-                        process_page(page_url)
+                        process_page(page_url, depth)
             else:
                 _run_page_pool(
                     page_threads=page_threads,
@@ -353,9 +362,9 @@ def crawl_site(options: CrawlOptions) -> CrawlStats:
 def _run_page_pool(
     *,
     page_threads: int,
-    q_pages: queue.Queue[str],
+    q_pages: queue.Queue[tuple[str, int]],
     claim_page: Callable[[str], bool],
-    process_page: Callable[[str], None],
+    process_page: Callable[[str, int], None],
     max_pages: int,
     seen_pages: set[str],
 ) -> None:
@@ -370,11 +379,11 @@ def _run_page_pool(
         while True:
             while len(seen_pages) < max_pages and len(pending) < page_threads:
                 try:
-                    page_url = q_pages.get_nowait()
+                    page_url, depth = q_pages.get_nowait()
                 except queue.Empty:
                     break
                 if claim_page(page_url):
-                    pending.add(pool.submit(process_page, page_url))
+                    pending.add(pool.submit(process_page, page_url, depth))
             if not pending:
                 break
             _done, pending = wait(pending, return_when=FIRST_COMPLETED)


### PR DESCRIPTION
Lets a crawl start from several URLs at once (repeated --url or a --url-file text file) and cap how many link-hops are followed from each one, instead of relying only on --max-pages. Useful for focusing a mirror on specific sections of a large site.

Closes #56

## Changes
- `--url` is now repeatable, and `--url-file FILE` reads additional starting URLs from a text file (one per line, `#` comments allowed)
- `--max-depth N` limits how many link-hops are followed from each starting URL (`0` = only the starting URLs themselves); omitted, depth is unlimited as before
- Crawl queue now tracks depth per page so it can be enforced without touching --max-pages behavior
- Tests for CLI parsing/file loading/validation, plus crawler tests for depth limiting and multi-seed crawls of disconnected site sections

## Test plan
- pytest -q (47 passed, includes rebase onto main after #57 merged)
- black --check, isort --check-only, ruff check, flake8 all clean